### PR TITLE
adds prefab scanner gates to the hop line and brig airlock

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1205,19 +1205,6 @@
 "adR" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
-"adS" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Head of Personnel's Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/ticket_machine{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "adU" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -16749,19 +16736,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"boX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Head of Personnel's Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "boY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20969,18 +20943,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/test_area)
-"bHA" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bHC" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -24972,13 +24934,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"caW" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics EVA";
-	req_one_access_txt = "11;24"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "cbc" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -27911,6 +27866,15 @@
 	},
 /turf/closed/wall,
 /area/engine/engineering)
+"cDP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "cDY" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -28547,6 +28511,20 @@
 /obj/item/kirbyplants,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cRS" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48";
+	shuttledocked = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "cSu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29759,28 +29737,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dFW" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dGD" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -30036,6 +29992,18 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dPx" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "dQc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -30265,6 +30233,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dZc" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dZd" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -30330,12 +30318,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ecA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "ecB" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31037,15 +31019,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"eCC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -31921,6 +31894,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"foI" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Dock";
+	req_access_txt = "48"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "foO" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -32454,15 +32446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"fGb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "fGf" = (
 /obj/machinery/smartfridge/disks{
 	pixel_y = 2
@@ -32863,6 +32846,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gap" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "gat" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -35990,6 +35982,20 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"imv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Head of Personnel's Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "inh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -36781,15 +36787,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"iZF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "iZK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -37623,6 +37620,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"jEl" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Head of Personnel's Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/ticket_machine{
+	pixel_y = 32
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -38796,6 +38807,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"kuv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "kvF" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -39463,15 +39480,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/entry)
-"kVW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "kWc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -39703,27 +39711,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"ldt" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ldx" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8
@@ -40246,6 +40233,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
+"lyN" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lzH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40444,6 +40453,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"lHo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "lHR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43345,16 +43369,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"nrM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "nrP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -43434,6 +43448,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nuR" = (
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory Mid"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "nvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -44223,6 +44243,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"nUv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "nUF" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/power/apc{
@@ -46537,21 +46567,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pyh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "pyk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48760,6 +48775,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"raX" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics EVA";
+	req_one_access_txt = "11;24"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "rba" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50091,6 +50113,15 @@
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rZl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "rZB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -50812,6 +50843,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"syD" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "szl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -52922,12 +52962,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"tZd" = (
-/obj/machinery/camera{
-	c_tag = "Chemistry - Factory Mid"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "tZh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53290,6 +53324,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"ulp" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ulN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -54127,25 +54190,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"uNI" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "uNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -54305,20 +54349,6 @@
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"uSM" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "uSY" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/fore";
@@ -55568,34 +55598,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vKx" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vKY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -58338,6 +58340,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
+"xAq" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xBf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58748,25 +58773,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xNu" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xNz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
@@ -80073,7 +80079,7 @@ aaa
 aaa
 lTa
 lTa
-uSM
+cRS
 lTa
 lTa
 aoV
@@ -80330,7 +80336,7 @@ aaf
 aaf
 lTa
 cvm
-ecA
+kuv
 lwd
 lTa
 aoV
@@ -80587,7 +80593,7 @@ aaa
 aaa
 lTa
 swZ
-ecA
+kuv
 poL
 lTa
 aoV
@@ -80844,7 +80850,7 @@ aaa
 bxy
 bxy
 qHP
-uNI
+foI
 gIj
 bxy
 aaf
@@ -81101,7 +81107,7 @@ bxy
 bxy
 ahw
 qvY
-bHA
+dPx
 jtD
 bxy
 aaH
@@ -81358,7 +81364,7 @@ svm
 agv
 byE
 bAZ
-ecA
+kuv
 bGm
 lTa
 aaf
@@ -81615,7 +81621,7 @@ bAb
 bzY
 bBa
 qrb
-iZF
+syD
 jAK
 lTa
 aaa
@@ -81868,11 +81874,11 @@ cLS
 hNJ
 eCu
 cLS
-pyh
-nrM
-fGb
-kVW
-eCC
+lHo
+nUv
+gap
+rZl
+cDP
 bKp
 lTa
 aaf
@@ -84684,12 +84690,12 @@ bjz
 qxt
 bjz
 bjz
-boX
+imv
 bqv
 bqv
 bqv
 bqv
-adS
+jEl
 aJw
 aJq
 edR
@@ -85170,7 +85176,7 @@ kgu
 jIG
 ayL
 jIG
-caW
+raX
 ayL
 jIG
 dTl
@@ -89519,10 +89525,10 @@ agn
 rnF
 nzl
 akr
-ldt
+lyN
 jOg
 alC
-vKx
+ulp
 anw
 anz
 rKh
@@ -90033,10 +90039,10 @@ adR
 aiQ
 hUs
 akt
-xNu
+dZc
 iGX
 amo
-dFW
+xAq
 anA
 anz
 aoD
@@ -100917,7 +100923,7 @@ rGg
 rGg
 chp
 mtK
-tZd
+nuR
 mSR
 cnf
 bip

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39036,7 +39036,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "csC" = (
@@ -72628,7 +72627,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "eXg" = (
@@ -74452,7 +74451,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fAA" = (
@@ -89328,7 +89327,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kby" = (
@@ -101328,7 +101327,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nPw" = (
@@ -129300,7 +129298,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wNN" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6448,11 +6448,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"awA" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "awB" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -18204,18 +18199,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"bgU" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 10;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/large;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "bgZ" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
@@ -18671,35 +18654,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/brig)
-"biz" = (
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
-"biA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"biB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "biC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -19819,27 +19773,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"bmf" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -39073,6 +39006,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"csB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "csC" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -58487,21 +58453,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/engine,
 /area/science/explab)
-"duz" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "duD" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -72651,6 +72602,35 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
+"eWW" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eXg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -72690,38 +72670,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"eXN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eYa" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -74486,6 +74434,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fAq" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foline";
+	name = "Queue Shutters"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/ticket_machine{
+	pixel_y = 32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fAA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -75834,22 +75803,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"fUx" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "fUA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75937,34 +75890,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
-"fVV" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fWb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -77174,23 +77099,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"grk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/auto_name/east,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/engine/storage_shared)
 "grm" = (
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp,
@@ -82752,6 +82660,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/medical/virology)
+"hZl" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "hZA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -84709,19 +84632,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"iEz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/brig_phys,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "iEK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -86052,18 +85962,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"iYL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "iYN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -86118,6 +86016,18 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
+/area/security/brig)
+"iZm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "iZG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86233,6 +86143,17 @@
 /obj/structure/cable/white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jbv" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "jbX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/purple,
@@ -88098,6 +88019,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"jDv" = (
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "jDP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -88466,6 +88397,27 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
+"jJS" = (
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "jKk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -88887,31 +88839,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"jSD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jSJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -89381,6 +89308,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"kbx" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kby" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -92347,26 +92297,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
-"lba" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foline";
-	name = "Queue Shutters"
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/ticket_machine{
-	pixel_y = 32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lbj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -92543,6 +92473,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
+"ldY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "lec" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -95176,6 +95116,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"mai" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 26;
+	use_power = 0
+	},
+/obj/structure/bed,
+/obj/machinery/camera{
+	c_tag = "Security - Medbay"
+	},
+/obj/machinery/iv_drip,
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "map" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -95520,17 +95481,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mhf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/landmark/start/brig_phys,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "mhh" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -95640,6 +95590,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
+"mit" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/landmark/start/brig_phys,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "miH" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -95865,6 +95826,23 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"mle" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/engine/storage_shared)
 "mlm" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Virology Lab";
@@ -99292,6 +99270,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"nhK" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "nhQ" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/plasma,
@@ -101311,6 +101305,32 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"nPu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nPw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -107205,6 +107225,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"pLz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "pLE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -108172,6 +108204,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
+"qcd" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 10;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/large;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "qce" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable{
@@ -112744,17 +112788,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"rAb" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "rAL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -117426,6 +117459,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tdO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/brig_phys,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "tea" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance";
@@ -118946,6 +118992,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"txZ" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "tyh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -119517,18 +119568,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"tHm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "tHo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -121118,28 +121157,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"uiL" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ujo" = (
 /obj/machinery/door/airlock{
 	name = "Lockerroom"
@@ -123082,27 +123099,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uOi" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 26;
-	use_power = 0
-	},
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Security - Medbay"
-	},
-/obj/machinery/iv_drip,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "uOB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -126310,6 +126306,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vSc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "vSk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -126632,6 +126637,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"vXW" = (
+/turf/open/space,
+/area/space)
 "vYg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable{
@@ -127996,9 +128004,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"wty" = (
-/turf/open/space,
-/area/space)
 "wtV" = (
 /obj/machinery/door/window/northright,
 /obj/effect/decal/cleanable/dirt,
@@ -129281,6 +129286,23 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"wNK" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foline";
+	name = "Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wNN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -133055,22 +133077,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"yeG" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foline";
-	name = "Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "yeH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -157157,7 +157163,7 @@ bvb
 bwv
 bxH
 bzl
-grk
+mle
 enB
 iXf
 bGk
@@ -163393,7 +163399,7 @@ caE
 aad
 gSi
 aVQ
-fUx
+nhK
 qQj
 gWu
 dKC
@@ -163641,7 +163647,7 @@ qLR
 mQs
 drM
 gFZ
-duz
+hZl
 wTa
 djF
 rfC
@@ -168477,12 +168483,12 @@ kWR
 bIH
 bUB
 bWO
-yeG
+wNK
 buq
 buq
 cen
 buq
-lba
+fAq
 bur
 bUB
 bUB
@@ -181045,7 +181051,7 @@ aad
 aaa
 aaa
 aaa
-bgU
+qcd
 aaa
 aaa
 aaa
@@ -182328,11 +182334,11 @@ aad
 aaa
 qYo
 aaa
-wty
-wty
-wty
-wty
-wty
+vXW
+vXW
+vXW
+vXW
+vXW
 aaa
 aad
 aad
@@ -182584,13 +182590,13 @@ aaa
 aad
 aaa
 qYo
-wty
+vXW
 aaa
 aaa
-wty
+vXW
 aaa
 aaa
-wty
+vXW
 gIC
 kNp
 bnG
@@ -182841,13 +182847,13 @@ aad
 aad
 aad
 aad
-wty
+vXW
 aaa
-wty
+vXW
 aaa
 aaa
-wty
-wty
+vXW
+vXW
 pZR
 bpd
 bre
@@ -183099,12 +183105,12 @@ aad
 aaa
 qYo
 aaa
-wty
+vXW
 aaa
 aaa
 aaa
 aaa
-wty
+vXW
 cSf
 sHj
 rNQ
@@ -183356,7 +183362,7 @@ aad
 aaa
 qYo
 aaa
-wty
+vXW
 aaa
 aaa
 aaa
@@ -183616,9 +183622,9 @@ aFm
 aFm
 bgZ
 bgZ
-biz
-rAb
-awA
+jDv
+jbv
+txZ
 bnG
 hNl
 brh
@@ -183639,9 +183645,9 @@ uNt
 nas
 ozc
 bgZ
-eXN
+csB
 kOm
-jSD
+nPu
 bgZ
 bgZ
 wJN
@@ -183871,10 +183877,10 @@ onf
 gmJ
 bcJ
 aFm
-iEz
-mhf
-biA
-iYL
+tdO
+mit
+vSc
+pLz
 bmd
 bnG
 uaf
@@ -184128,11 +184134,11 @@ fNF
 kvB
 bcK
 aFm
-uOi
-tHm
-biB
+mai
+iZm
+ldY
 oGZ
-bmf
+jJS
 bnG
 wph
 iGM
@@ -184410,9 +184416,9 @@ wJN
 wwv
 biC
 bNj
-fVV
+eWW
 oeI
-uiL
+kbx
 bNj
 urs
 sFk

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -916,26 +916,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/white,
 /area/medical)
-"afR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/camera{
-	c_tag = "Medbay - Chemistry";
-	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "afW" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
@@ -1232,20 +1212,6 @@
 	dir = 8
 	},
 /obj/structure/chair,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"ahG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ahI" = (
@@ -1866,10 +1832,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"akB" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "akI" = (
 /obj/machinery/computer/communications,
 /obj/effect/turf_decal/tile/blue{
@@ -2228,6 +2190,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"amF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	dir = 10;
+	pixel_x = -23;
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "amJ" = (
 /obj/machinery/computer/monitor{
 	dir = 8
@@ -2251,20 +2244,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"amL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "amN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2384,10 +2363,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"anG" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
 "anI" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/line{
@@ -2567,16 +2542,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"aoy" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "aoA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/blue,
@@ -2594,12 +2559,6 @@
 /area/hydroponics)
 "aoC" = (
 /obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aoD" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aoJ" = (
@@ -2689,12 +2648,6 @@
 "apq" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"apr" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "apt" = (
@@ -2843,23 +2796,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"aqd" = (
-/obj/structure/displaycase/labcage,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Science - Research Director's Office";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "aqi" = (
@@ -3113,12 +3049,6 @@
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"arw" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "arx" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3424,13 +3354,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"atM" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "atQ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -3998,6 +3921,17 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"aBn" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "aBw" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/tile/red{
@@ -4195,6 +4129,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"aDX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "aEh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 4
@@ -4589,6 +4533,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"aIf" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "aIg" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -4683,19 +4633,6 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"aJv" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "aJB" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -4763,22 +4700,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aKr" = (
-/obj/machinery/door/window{
-	base_state = "rightsecure";
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "Primary AI Core Access";
-	obj_integrity = 300;
-	req_access_txt = "16"
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/airalarm/directional/west,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "aKD" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -5055,6 +4976,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"aNE" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/light/small,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "aNF" = (
 /obj/structure/chair{
 	dir = 1
@@ -5106,6 +5034,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"aOb" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "aOi" = (
 /turf/open/floor/engine,
 /area/science/explab)
@@ -5617,6 +5552,26 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
+"aWL" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry";
+	dir = 4;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "aWR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5875,20 +5830,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/main)
-"bpd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera{
-	c_tag = "Security - Equipment Room Aft";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "bpn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -6094,6 +6035,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"bBI" = (
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = -26;
+	pixel_y = 6
+	},
+/obj/machinery/button/door{
+	id = "hosprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = -26;
+	pixel_y = -6
+	},
+/obj/structure/closet/secure_closet/hos,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "bCi" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -6217,6 +6179,27 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"bIb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"bIU" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "bJn" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
@@ -6311,23 +6294,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bRi" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/south,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/light_switch{
-	dir = 10;
-	pixel_x = -23;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/toilet)
 "bSt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -6534,6 +6500,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"ccf" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera{
+	c_tag = "Departures - Fore";
+	dir = 4;
+	name = "departures camera"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "ccN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -6563,6 +6538,16 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"cgM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/stasis,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "cgT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable{
@@ -6594,17 +6579,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ckw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel,
-/area/security/checkpoint)
 "ckI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -6727,6 +6701,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"cst" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ctC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/auto_name/west{
@@ -7098,6 +7077,21 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"cNR" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio,
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/west{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint)
 "cOx" = (
 /obj/machinery/power/deck_relay,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -7115,6 +7109,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cUf" = (
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber - Fore";
+	dir = 6;
+	name = "motion-sensitive ai camera";
+	network = list("aichamber")
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "cUC" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -7288,16 +7292,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
-"dgG" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/cable{
-	icon_state = "0-8"
+"dgy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/airalarm/directional/east,
+/obj/item/paicard,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "djC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -7456,6 +7465,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hos)
+"dtY" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dvC" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light{
@@ -7575,16 +7601,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"dEO" = (
-/obj/effect/turf_decal/stripes/line{
+"dEV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/camera{
+	c_tag = "AI Satellite - Antechamber";
+	dir = 8;
+	name = "ai camera";
+	network = list("minisat");
+	start_active = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/ai_monitored/turret_protected/aisat_interior)
 "dEW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7773,22 +7813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dYm" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "dZk" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -8297,6 +8321,14 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
+"eGM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/dna_scannernew,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "eHc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -8395,6 +8427,20 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"ePU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "ePW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -8511,16 +8557,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"eXD" = (
-/obj/structure/table/reinforced,
-/obj/item/hemostat,
-/obj/item/surgicaldrill,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "eZK" = (
 /obj/machinery/light{
 	dir = 4
@@ -8564,6 +8600,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"fdT" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/light_switch{
+	dir = 10;
+	pixel_x = -23;
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet)
 "ffR" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -8576,6 +8629,12 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
+"fjT" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fld" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/rack,
@@ -8595,6 +8654,16 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"fqj" = (
+/obj/structure/table/reinforced,
+/obj/item/hemostat,
+/obj/item/surgicaldrill,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "fqI" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -8711,6 +8780,31 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"fys" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fAq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8938,6 +9032,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"fVs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/landmark/start/chief_medical_officer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Chief Medical Officer's Office";
+	dir = 8;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "fWK" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9099,21 +9214,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"gkf" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/vehicle/ridden/wheelchair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/white,
-/area/medical)
 "gkg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9129,6 +9229,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"gkk" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "glV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -9141,6 +9251,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"gma" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gmB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9223,6 +9349,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"grV" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "gsO" = (
 /obj/item/kirbyplants/dead,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9402,20 +9538,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
-"gLn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/sink{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "gMl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -9492,6 +9614,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"gUX" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/computer/telecomms/monitor{
+	dir = 4;
+	network = "tcommsat"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "gVM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/cola/random,
@@ -9528,17 +9661,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
-"gYn" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/bar)
 "gYA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -9698,23 +9820,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"hkY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "hkZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9816,16 +9921,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
-"hzq" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber - Fore";
-	dir = 6;
-	name = "motion-sensitive ai camera";
-	network = list("aichamber")
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "hAM" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenic Lounge"
@@ -9914,10 +10009,11 @@
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
-"hGg" = (
-/obj/machinery/airalarm/directional/east,
+"hHB" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/area/crew_quarters/bar)
 "hHO" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -9989,6 +10085,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"hOm" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "hPw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -10112,11 +10212,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hWV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
+"hXm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/maintenance/department/science)
 "hXJ" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Lab";
@@ -10292,6 +10397,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"idZ" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Vault - Lower";
+	dir = 8;
+	network = list("vault")
+	},
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "Vault"
+	},
+/turf/open/floor/vault,
+/area/ai_monitored/nuke_storage)
+"ieD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/explab)
 "ieP" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/decal/cleanable/dirt,
@@ -10300,22 +10433,19 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"ifz" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
+"ifQ" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/crew_quarters/dorms)
 "ifT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -10549,6 +10679,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"iCu" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "iDQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10887,6 +11023,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jfM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "jjX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -11248,16 +11401,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"jKr" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera{
-	c_tag = "Bridge - Captain's Quarters";
-	name = "command camera"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/crew_quarters/heads/captain/private)
 "jMK" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -11296,6 +11439,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jON" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "jOP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -11545,36 +11695,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"kew" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/noslip,
-/area/engine/break_room)
-"keN" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = 25
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "kgq" = (
 /obj/machinery/door/window/brigdoor/security/cell/northright{
 	name = "Cell 2"
@@ -11741,20 +11861,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ksu" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "ksA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -11896,6 +12002,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"kCe" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "kCf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment{
@@ -12114,6 +12234,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"kUW" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -23;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "kVW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -12162,21 +12293,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"kYx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/stasis,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "kZW" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"lbF" = (
+/obj/machinery/computer/security/hos{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 6;
+	name = "Head of Security RC";
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "lcd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -12326,13 +12464,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"lsB" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "lsJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12503,25 +12634,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/comms)
-"lMo" = (
-/obj/structure/ladder{
-	name = "service ladder"
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 6;
-	pixel_x = 23;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "lNf" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom{
@@ -12599,30 +12711,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/crew_quarters/dorms)
-"lRz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/camera{
-	c_tag = "AI Satellite - Antechamber";
-	dir = 8;
-	name = "ai camera";
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "lUu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12682,14 +12770,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"mdz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/dna_scannernew,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "meO" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable{
@@ -12697,16 +12777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
-"mff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/science)
 "mfk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -12766,6 +12836,23 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
+"mmO" = (
+/obj/structure/displaycase/labcage,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Research Director's Office";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "mnP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -12823,14 +12910,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"msF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "muR" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -12949,29 +13028,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"mEr" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/camera/motion{
-	c_tag = "Vault - Lower";
-	dir = 8;
-	network = list("vault")
-	},
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "Vault"
-	},
-/turf/open/floor/vault,
-/area/ai_monitored/nuke_storage)
-"mFn" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/light/small,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/medical/storage)
 "mFX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -13147,34 +13203,6 @@
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mTB" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/paper_bin,
-/obj/item/pen/red,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"mTK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/airalarm/directional/east,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "mTM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
@@ -13215,27 +13243,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
-"mUY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Chief Medical Officer's Office";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "mVH" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -13263,30 +13270,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"mWE" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mWI" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -13405,6 +13388,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"neB" = (
+/obj/machinery/door/window{
+	base_state = "rightsecure";
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "Primary AI Core Access";
+	obj_integrity = 300;
+	req_access_txt = "16"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "nfl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13418,6 +13417,25 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
+"nfp" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nfr" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -13434,6 +13452,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"nfX" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "nhy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -13619,22 +13648,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nwd" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "nxI" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -13718,6 +13731,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"nCz" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "nCG" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8;
@@ -14062,10 +14083,6 @@
 /obj/effect/turf_decal/atmos/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"okk" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/circuit/green,
-/area/ai_monitored/nuke_storage)
 "okE" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -14076,6 +14093,22 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"okZ" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "oll" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -14330,6 +14363,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
+"oFu" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Bridge - Captain's Quarters";
+	name = "command camera"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain/private)
 "oGd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -14349,11 +14392,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"oGL" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "oHP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -14383,6 +14421,25 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oKc" = (
+/obj/structure/ladder{
+	name = "service ladder"
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 6;
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "oMh" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
@@ -14405,6 +14462,31 @@
 /obj/item/storage/box/ingredients,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"oOF" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
+"oPc" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "oPz" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14436,24 +14518,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
-"oQy" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/bed/dogbed/ian,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/mob/living/simple_animal/pet/dog/corgi/Ian,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	dir = 5;
-	name = "Head of Personnel RC";
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/head_of_personnel)
 "oQO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14498,6 +14562,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"oUp" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/paper_bin,
+/obj/item/pen/red,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "oVq" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -14513,16 +14590,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"oVF" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "oVI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -14594,6 +14661,28 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"oYB" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/requests_console{
+	department = "Genetics";
+	name = "Genetics Requests Console";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "oZo" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -14855,6 +14944,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"pjo" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "pjz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -15025,6 +15118,21 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical)
+"pyK" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/vehicle/ridden/wheelchair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/medical)
 "pyV" = (
@@ -15265,17 +15373,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
-"pMm" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -23;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "pOR" = (
 /obj/machinery/door/window{
 	base_state = "rightsecure";
@@ -15335,23 +15432,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"pSo" = (
-/obj/machinery/computer/security/hos{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	dir = 6;
-	name = "Head of Security RC";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "pUK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -15383,22 +15463,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"pYi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qbR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -15641,28 +15705,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"qDl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qFn" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -15688,6 +15730,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"qFI" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar)
 "qFL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -15828,6 +15881,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"qNZ" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/bed/dogbed/ian,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/mob/living/simple_animal/pet/dog/corgi/Ian,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	dir = 5;
+	name = "Head of Personnel RC";
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/head_of_personnel)
 "qQf" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line,
@@ -15879,24 +15950,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"qUO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qXt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15946,6 +15999,43 @@
 /obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"rbw" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/camera{
+	c_tag = "Locker Room";
+	dir = 4;
+	name = "dormitories camera"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/locker_room)
+"rcd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel,
+/area/security/checkpoint)
 "rcN" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -16004,21 +16094,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ai_monitored/turret_protected/ai_upload)
-"rkv" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/science)
 "rlh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment{
@@ -16063,32 +16138,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"rmI" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/camera{
-	c_tag = "Locker Room";
-	dir = 4;
-	name = "dormitories camera"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/locker_room)
 "rmU" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/table/wood,
@@ -16324,17 +16373,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"rGZ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
 "rHc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -16423,13 +16461,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"rNM" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "rNV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -16550,18 +16581,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"rVJ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/item/paper_bin,
-/turf/open/floor/plasteel,
-/area/science/lab)
 "rYq" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/status_display/ai{
@@ -16617,6 +16636,16 @@
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
+"sfC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/noslip,
+/area/engine/break_room)
 "sfJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -16650,11 +16679,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/comms)
-"sjW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "slF" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -16672,17 +16696,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"smg" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/computer/telecomms/monitor{
-	dir = 4;
-	network = "tcommsat"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "snB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -16719,21 +16732,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
-"suT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/radio,
-/obj/structure/cable,
-/obj/structure/window/reinforced/spawner/west{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint)
 "svj" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Research Director's Office Maintenance";
@@ -16916,6 +16914,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"sHC" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/circuit,
+/area/science/robotics/mechbay)
 "sIP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -16939,6 +16941,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"sKA" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sMl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -17129,28 +17154,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"tal" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "taD" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/delivery,
@@ -17174,22 +17177,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tcX" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tdg" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -17421,6 +17408,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"tvG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "twN" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Science Maintenance";
@@ -17695,6 +17687,22 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tXX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "tYA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -17770,15 +17778,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
-"udd" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/camera{
-	c_tag = "Departures - Fore";
-	dir = 4;
-	name = "departures camera"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "udm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17877,35 +17876,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"unV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	dir = 6;
-	pixel_x = 23;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "uoK" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -18185,17 +18155,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
-"uUt" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
 "uUK" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -18305,18 +18264,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"uZi" = (
-/obj/vehicle/ridden/janicart,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = 30
-	},
-/obj/item/key/janitor,
-/turf/open/floor/plating,
-/area/janitor)
 "uZn" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -18470,6 +18417,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"vhj" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/paper_bin,
+/turf/open/floor/plasteel,
+/area/science/lab)
 "vhS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18696,6 +18655,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vzS" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 6;
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "vAM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance";
@@ -18779,6 +18767,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
+"vHd" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vIS" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
@@ -18853,6 +18857,20 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vPr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera{
+	c_tag = "Security - Equipment Room Aft";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "vQF" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -18977,6 +18995,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vZV" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/nuke_storage)
 "waH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19138,37 +19160,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wsi" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light_switch{
-	dir = 10;
-	pixel_x = -23;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "wsP" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/circuit/green,
@@ -19324,6 +19315,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wBw" = (
+/obj/vehicle/ridden/janicart,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/obj/item/key/janitor,
+/turf/open/floor/plating,
+/area/janitor)
+"wDF" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "wDG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -19781,6 +19804,20 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"xno" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/sink{
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "xnZ" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -20145,18 +20182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"xIT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
 "xJc" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -20460,27 +20485,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"ybe" = (
-/obj/machinery/button/door{
-	id = "hosspace";
-	name = "Space Shutters Control";
-	pixel_x = -26;
-	pixel_y = 6
-	},
-/obj/machinery/button/door{
-	id = "hosprivacy";
-	name = "Privacy Shutters Control";
-	pixel_x = -26;
-	pixel_y = -6
-	},
-/obj/structure/closet/secure_closet/hos,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = 25
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "ycc" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -44557,10 +44561,10 @@ gPS
 sxG
 ahI
 ahI
-hzq
+cUf
 ajk
 aiO
-aKr
+neB
 fTG
 pOR
 aiO
@@ -46099,7 +46103,7 @@ rpf
 dIh
 gxw
 jai
-smg
+gUX
 akz
 akR
 alt
@@ -46603,7 +46607,7 @@ jpq
 slF
 wni
 wim
-hWV
+tvG
 aIU
 aaa
 agD
@@ -46855,7 +46859,7 @@ xMc
 aBJ
 uGU
 vbo
-tcX
+vHd
 gXl
 nKg
 cuJ
@@ -46869,14 +46873,14 @@ ahK
 aie
 aiC
 ahh
-lRz
+dEV
 ixt
 qYD
 akR
 alv
 rrp
-amL
-hkY
+ePU
+jfM
 amg
 nau
 apa
@@ -47398,7 +47402,7 @@ afZ
 afZ
 aaa
 aFx
-ksu
+kCe
 aXk
 aGi
 aGS
@@ -47882,12 +47886,12 @@ aaa
 aaa
 bgS
 jAU
-lsB
+aOb
 vML
 mQD
 wLT
 mXJ
-kew
+sfC
 pQo
 abv
 afZ
@@ -48395,7 +48399,7 @@ aaX
 aaT
 aaT
 dne
-udd
+ccf
 lcd
 sTS
 efh
@@ -48431,7 +48435,7 @@ aFx
 aFx
 aFx
 aDt
-msF
+nCz
 wXz
 aDt
 afP
@@ -48920,8 +48924,8 @@ tNR
 aJP
 agb
 axX
-uUt
-hGg
+nfX
+hOm
 vxJ
 svp
 aSm
@@ -48939,9 +48943,9 @@ arM
 aTL
 aEV
 pAi
-rkv
+oPc
 mzF
-mff
+hXm
 jNp
 tdr
 bnk
@@ -49968,7 +49972,7 @@ rzD
 mOJ
 gsO
 apG
-aqd
+mmO
 aqs
 aqH
 xKT
@@ -50461,10 +50465,10 @@ aee
 afd
 bfV
 dro
-ckw
+rcd
 nmn
 aee
-pMm
+kUW
 aRj
 pEI
 kXR
@@ -50480,7 +50484,7 @@ ajj
 aot
 aoQ
 vuj
-apr
+fjT
 aKW
 gUh
 aDM
@@ -50742,7 +50746,7 @@ aKW
 rHf
 ahc
 rvi
-xIT
+ieD
 aKW
 eHm
 aqR
@@ -50975,7 +50979,7 @@ aee
 gYA
 tvj
 tsx
-suT
+cNR
 jFm
 aee
 syY
@@ -51248,7 +51252,7 @@ avG
 anh
 anD
 kiz
-rVJ
+vhj
 alM
 xsC
 krW
@@ -51488,14 +51492,14 @@ sDg
 aeg
 wwD
 lVL
-mFn
+aNE
 agJ
 ahp
 ahP
 aig
 fTP
 qGu
-tal
+oYB
 agJ
 teQ
 kXd
@@ -51996,7 +52000,7 @@ aRC
 aYD
 qQq
 abU
-eXD
+fqj
 afb
 aMn
 aeg
@@ -52253,7 +52257,7 @@ aRC
 aYD
 xrY
 abU
-gLn
+xno
 rnV
 adv
 aeg
@@ -52274,7 +52278,7 @@ eIk
 aPp
 amx
 amx
-anG
+sHC
 aod
 taD
 aoR
@@ -52787,13 +52791,13 @@ xye
 oly
 alP
 bwT
-rNM
+jON
 anI
 aod
 wnA
 rLJ
-aoy
-oVF
+gkk
+oOF
 pej
 rmz
 bpy
@@ -53283,13 +53287,13 @@ hkZ
 abV
 bZv
 gtV
-kYx
+cgM
 aIN
 kPL
 afG
 amz
 aMR
-mdz
+eGM
 mWI
 qZk
 rZG
@@ -53553,7 +53557,7 @@ rZG
 agJ
 agJ
 agJ
-atM
+bIU
 kXd
 eDf
 aPo
@@ -53803,7 +53807,7 @@ aeT
 afM
 pym
 kTa
-gkf
+pyK
 dsV
 ahu
 aiI
@@ -54338,7 +54342,7 @@ aoA
 apz
 pAM
 oMW
-arw
+iCu
 arT
 ase
 aqb
@@ -54589,8 +54593,8 @@ amA
 qFs
 anM
 lAn
-aoD
-dgG
+aIf
+grV
 utd
 jmJ
 apL
@@ -55103,7 +55107,7 @@ bwS
 atm
 kyK
 xOV
-oGL
+hHB
 brf
 oXw
 cwD
@@ -55343,8 +55347,8 @@ wZf
 aep
 pfE
 bHJ
-dYm
-mUY
+tXX
+fVs
 fsU
 pfE
 ahA
@@ -55856,7 +55860,7 @@ cwa
 adC
 aew
 qQf
-afR
+aWL
 agn
 wYe
 ahB
@@ -56632,8 +56636,8 @@ rVi
 agU
 ahE
 ahY
-ahG
-mTK
+bIb
+dgy
 aQS
 mPz
 aHn
@@ -56651,7 +56655,7 @@ eTD
 aFQ
 dxr
 arg
-uZi
+wBw
 aQu
 rDI
 nzi
@@ -57162,7 +57166,7 @@ aol
 amk
 anS
 rmU
-gYn
+qFI
 hNq
 ylu
 xHz
@@ -57655,10 +57659,10 @@ adg
 adF
 pds
 aar
-ifz
+dtY
 abC
 abC
-qUO
+nfp
 wNW
 aia
 aia
@@ -57912,10 +57916,10 @@ rPk
 vIT
 kip
 iYq
-qDl
+sKA
 tZi
 tZi
-mWE
+fys
 ptK
 eFS
 qFL
@@ -58178,7 +58182,7 @@ pxa
 jtN
 jtN
 tCR
-sjW
+cst
 exZ
 aYh
 ala
@@ -58685,7 +58689,7 @@ abC
 abC
 abC
 agp
-pYi
+gma
 aaB
 aia
 pxa
@@ -58704,7 +58708,7 @@ ykj
 jtN
 oEB
 aEs
-bRi
+fdT
 apd
 whn
 arG
@@ -59191,7 +59195,7 @@ aAH
 xqh
 vpN
 gHy
-mTB
+oUp
 etN
 ygz
 jcm
@@ -59219,7 +59223,7 @@ jtN
 aCT
 lzS
 xnZ
-rmI
+rbw
 aMY
 pLy
 aHi
@@ -59710,7 +59714,7 @@ asM
 uiU
 oiT
 nJg
-unV
+vzS
 lKe
 nIa
 ntT
@@ -59719,11 +59723,11 @@ hAU
 xul
 cPn
 ajc
-jKr
+oFu
 agK
 ajF
 aMM
-oQy
+qNZ
 tpT
 sUq
 ama
@@ -60218,7 +60222,7 @@ aaa
 aLG
 aLG
 jDh
-dEO
+aDX
 idd
 uWy
 qXt
@@ -60235,10 +60239,10 @@ jtN
 ajd
 ajr
 qLZ
-akB
+pjo
 ali
 ajN
-keN
+wDF
 iNj
 ama
 eFj
@@ -61273,7 +61277,7 @@ ldv
 ykj
 jtN
 apj
-nwd
+okZ
 apj
 fGB
 bLA
@@ -61787,7 +61791,7 @@ osw
 nYy
 blk
 apj
-aJv
+ifQ
 apj
 apj
 apj
@@ -62036,7 +62040,7 @@ xox
 akt
 crV
 voW
-rGZ
+aBn
 asR
 jrv
 aje
@@ -62531,7 +62535,7 @@ aaa
 aaa
 aMH
 aMH
-ybe
+bBI
 aAC
 usD
 epO
@@ -62540,9 +62544,9 @@ aOs
 pHH
 aTs
 utY
-bpd
+vPr
 bix
-okk
+vZV
 tHF
 wsP
 bix
@@ -62552,7 +62556,7 @@ urx
 fqS
 wcX
 xXM
-wsi
+amF
 ajg
 nml
 kut
@@ -62800,7 +62804,7 @@ piH
 aSY
 bix
 ydc
-mEr
+idZ
 llf
 bix
 nvB
@@ -62813,7 +62817,7 @@ dwQ
 ajg
 axV
 sUw
-lMo
+oKc
 aEy
 acs
 tdg
@@ -63050,7 +63054,7 @@ aAC
 apl
 aZq
 iZX
-pSo
+lbF
 ath
 afW
 glV

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -7479,7 +7479,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dvC" = (
@@ -7916,6 +7916,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
+"efZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
 "egg" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/kirbyplants/random,
@@ -8802,7 +8806,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fAq" = (
@@ -10000,6 +10003,11 @@
 	dir = 8;
 	name = "hallway camera"
 	},
+/obj/machinery/scanner_gate/hop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hFU" = (
@@ -10788,6 +10796,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/scanner_gate/hop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iQv" = (
@@ -13433,7 +13446,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nfr" = (
@@ -15308,6 +15320,10 @@
 "pJH" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon/wayfinding/hop,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pKm" = (
@@ -16961,7 +16977,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sMl" = (
@@ -58174,8 +58190,8 @@ qxJ
 arK
 oRy
 aaB
-aaB
-aaB
+efZ
+efZ
 aaB
 oQO
 pxa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -369,7 +369,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "acE" = (
@@ -1423,7 +1423,6 @@
 "ajM" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics EVA";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /turf/open/floor/plasteel/dark,
@@ -6501,7 +6500,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -6879,7 +6877,6 @@
 	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/hallway/primary/aft";
-	dir = 2;
 	name = "Aft Hallway APC";
 	pixel_y = -24
 	},
@@ -11365,8 +11362,7 @@
 /area/maintenance/starboard)
 "bom" = (
 /obj/machinery/camera{
-	c_tag = "Aft Hallway - Engineering Cafe";
-	dir = 2
+	c_tag = "Aft Hallway - Engineering Cafe"
 	},
 /turf/open/floor/wood,
 /area/engine/break_room)
@@ -11893,9 +11889,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bre" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/mug/tea{
 	pixel_x = 6;
@@ -13010,7 +13004,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/engine,
@@ -17828,7 +17821,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -28003,8 +27995,7 @@
 /area/science/explab)
 "dGJ" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Apiary";
-	req_access_txt = "0"
+	name = "Apiary"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -28189,7 +28180,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/structure/disposalpipe/segment{
@@ -28336,7 +28326,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/engine,
@@ -28598,14 +28587,12 @@
 	},
 /obj/item/chair/plastic,
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/chair/plastic{
 	pixel_y = 8
 	},
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/dark,
@@ -29006,7 +28993,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -31118,7 +31104,6 @@
 "eFp" = (
 /obj/machinery/door/airlock/security{
 	name = "Courtroom";
-	req_access_txt = "0";
 	req_one_access_txt = "38; 63"
 	},
 /obj/structure/cable{
@@ -31854,8 +31839,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/medical{
-	name = "Chemistry";
-	req_access_txt = "0"
+	name = "Chemistry"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -32839,9 +32823,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "ffW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -33635,7 +33617,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
@@ -34430,7 +34411,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fzX" = (
@@ -35907,7 +35887,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -36543,9 +36522,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
@@ -37796,7 +37773,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -39244,9 +39220,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "gSP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -39488,7 +39462,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gWp" = (
@@ -41037,7 +41011,6 @@
 	},
 /obj/item/camera,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -48164,9 +48137,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jAM" = (
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/lawoffice)
 "jAV" = (
@@ -48269,10 +48240,7 @@
 	pixel_y = 7
 	},
 /obj/item/pinpointer/nuke,
-/obj/item/disk/nuclear{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/disk/nuclear,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "jCT" = (
@@ -52174,7 +52142,6 @@
 /obj/item/beacon,
 /obj/machinery/camera{
 	c_tag = "Fore Hallway Vault";
-	dir = 2;
 	name = "fore camera"
 	},
 /turf/open/floor/plasteel,
@@ -52198,7 +52165,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
-	dir = 2;
 	node1_concentration = 0.21;
 	node2_concentration = 0.79
 	},
@@ -52214,9 +52180,7 @@
 	},
 /area/maintenance/port)
 "kKl" = (
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -56781,7 +56745,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/courtroom";
-	dir = 2;
 	name = "Courtroom APC";
 	pixel_y = -24
 	},
@@ -57306,7 +57269,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -57563,7 +57525,6 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Courtroom";
-	req_access_txt = "0";
 	req_one_access_txt = "38; 63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -58054,7 +58015,6 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/flashlight/lamp/green{
@@ -58134,7 +58094,6 @@
 "moa" = (
 /obj/machinery/camera{
 	c_tag = "Atrium Vendors";
-	dir = 2;
 	name = "diner camera"
 	},
 /obj/structure/chair/sofa/left{
@@ -59324,9 +59283,7 @@
 	name = "Upload navigation beacon"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mDF" = (
@@ -60422,8 +60379,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Security Equipment Room";
-	dir = 2
+	c_tag = "Security Equipment Room"
 	},
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -60531,7 +60487,6 @@
 /area/crew_quarters/bar)
 "mVa" = (
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -60630,7 +60585,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -61287,7 +61241,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -63339,9 +63292,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_y = 0
-	},
+/obj/item/tank/jetpack/carbondioxide,
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -65808,9 +65759,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ovM" = (
@@ -70453,7 +70402,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -70828,7 +70776,7 @@
 	id = "foqueue";
 	name = "Queue Shutters"
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "qgs" = (
@@ -72511,7 +72459,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/box,
@@ -72679,7 +72626,6 @@
 	pixel_x = 28
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/circuit/green{
@@ -73696,7 +73642,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -73769,7 +73714,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -74155,7 +74099,6 @@
 "rjM" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	dir = 2;
 	name = "Upload APC";
 	pixel_y = -24
 	},
@@ -74233,14 +74176,12 @@
 	},
 /obj/item/chair/plastic,
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/chair/plastic{
 	pixel_y = 8
 	},
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/dark,
@@ -76047,9 +75988,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/main)
 "rQi" = (
@@ -77594,7 +77533,6 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/item/pen{
@@ -77951,9 +77889,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -78004,7 +77940,6 @@
 /area/storage/primary)
 "stW" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -80490,7 +80425,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -83582,7 +83516,6 @@
 /area/maintenance/central)
 "tYC" = (
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -84807,9 +84740,7 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "uuL" = (
@@ -85437,7 +85368,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -85660,9 +85590,7 @@
 /area/maintenance/aft)
 "uKi" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "uKq" = (
@@ -86187,7 +86115,7 @@
 	id = "foqueue";
 	name = "Queue Shutters"
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "uSy" = (
@@ -88453,7 +88381,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white,
@@ -90513,9 +90440,7 @@
 	pixel_y = -32;
 	receive_ore_updates = 1
 	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "wne" = (
@@ -90563,7 +90488,6 @@
 /obj/item/reagent_containers/pill/mannitol,
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /obj/machinery/power/apc{
@@ -91507,9 +91431,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "wBv" = (
@@ -92590,9 +92512,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "wSu" = (
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -94489,8 +94409,6 @@
 /area/maintenance/fore)
 "xtS" = (
 /obj/machinery/computer/security/telescreen/interrogation{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/tile/red{
@@ -94994,8 +94912,7 @@
 /area/hallway/primary/central)
 "xBo" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Apiary";
-	req_one_access_txt = "0"
+	name = "Apiary"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -95230,7 +95147,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xEf" = (
@@ -95919,7 +95835,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -97065,9 +96980,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "yhK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -357,6 +357,21 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"acz" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "acE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -2926,16 +2941,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"atu" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Queue Shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/head_of_personnel)
 "atv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -17834,14 +17839,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bZe" = (
-/obj/effect/turf_decal/loading_area,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Queue Shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/head_of_personnel)
 "bZl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -34414,6 +34411,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"fzH" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fzX" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -39454,6 +39473,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"gWo" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gWp" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -48718,23 +48755,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"jJo" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jJC" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -51998,23 +52018,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kHT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kIb" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/solars/starboard/fore";
@@ -55377,20 +55380,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
-"lAT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lAY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -60205,27 +60194,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard)
-"mRA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "mRD" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -70854,6 +70822,15 @@
 /obj/item/camera,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
+"qgp" = (
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Queue Shutters"
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/head_of_personnel)
 "qgs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -86202,6 +86179,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"uRR" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Queue Shutters"
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/head_of_personnel)
 "uSy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -95227,6 +95215,24 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port)
+"xDQ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xEf" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -120503,9 +120509,9 @@ aef
 hpm
 wSu
 aef
-lAT
+acz
 gEZ
-jJo
+gWo
 aaj
 fsj
 jhY
@@ -121274,9 +121280,9 @@ aef
 ksV
 wsC
 agX
-kHT
+xDQ
 gEZ
-mRA
+fzH
 aaf
 aTH
 qRy
@@ -125117,7 +125123,7 @@ jQS
 tTJ
 atC
 jPl
-atu
+uRR
 bRG
 dhr
 hab
@@ -126145,7 +126151,7 @@ yfk
 bui
 loZ
 bzM
-bZe
+qgp
 bRG
 noY
 mxV

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -45710,7 +45710,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fEB" = (
@@ -46886,7 +46886,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gje" = (
@@ -50826,7 +50826,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "hRu" = (
@@ -59133,7 +59133,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "lvn" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10161,24 +10161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"aPh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aPi" = (
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/watermelon,
@@ -14883,39 +14865,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"bgB" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/under/rank/security/warden,
-/obj/item/clothing/suit/armor/vest/security/warden,
-/obj/item/clothing/under/rank/security/head_of_security,
-/obj/item/clothing/suit/armor/vest/security/hos,
-/obj/item/clothing/head/beret/sec/officer,
-/obj/item/clothing/head/beret/sec/officer,
-/obj/item/clothing/head/beret/sec/officer,
-/obj/item/clothing/head/beret/sec/officer,
-/obj/item/clothing/head/beret/sec/officer,
-/obj/item/clothing/head/beret/sec/officer,
-/obj/item/clothing/head/beret/sec/warden,
-/obj/item/clothing/head/beret/sec/hos,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/warden)
 "bgD" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26645,10 +26594,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"cfa" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "cfq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -31846,13 +31791,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
-"cxH" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "cxJ" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -41629,30 +41567,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"dMy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/navbeacon/wayfinding,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dMC" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41753,6 +41667,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dNQ" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "dNU" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -45767,6 +45688,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"fEy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fEB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46924,6 +46870,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gjd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gje" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48496,19 +48461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"gUy" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Head of Personnel's Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "gUD" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -50863,6 +50815,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hQt" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Head of Personnel's Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "hRu" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -56538,6 +56504,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kuy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kvt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -58715,6 +58706,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"lpi" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "lpp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Detective Maintenance";
@@ -59126,6 +59121,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"lve" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Head of Personnel's Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "lvn" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -60648,6 +60658,39 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/miningoffice)
+"mhL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/flasher{
+	id = "secentranceflasher";
+	pixel_x = 25
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mhN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -69753,30 +69796,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/central)
-"qct" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qcI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
@@ -76476,20 +76495,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"sWM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Head of Personnel's Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "sWQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -83170,38 +83175,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"wca" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/flasher{
-	id = "secentranceflasher";
-	pixel_x = 25
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wde" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -84519,6 +84492,39 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/prison)
+"wIE" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/under/rank/security/warden,
+/obj/item/clothing/suit/armor/vest/security/warden,
+/obj/item/clothing/under/rank/security/head_of_security,
+/obj/item/clothing/suit/armor/vest/security/hos,
+/obj/item/clothing/head/beret/sec/officer,
+/obj/item/clothing/head/beret/sec/officer,
+/obj/item/clothing/head/beret/sec/officer,
+/obj/item/clothing/head/beret/sec/officer,
+/obj/item/clothing/head/beret/sec/officer,
+/obj/item/clothing/head/beret/sec/officer,
+/obj/item/clothing/head/beret/sec/warden,
+/obj/item/clothing/head/beret/sec/hos,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/warden)
 "wJh" = (
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/air_tank{
@@ -111574,7 +111580,7 @@ umS
 qez
 bol
 bzL
-gUy
+hQt
 bDb
 saq
 fEk
@@ -112859,7 +112865,7 @@ hyq
 cgY
 xad
 aiv
-sWM
+lve
 ygQ
 jRO
 bGC
@@ -114867,7 +114873,7 @@ aeq
 aeq
 aeq
 aeq
-bgB
+wIE
 tmD
 oum
 qvZ
@@ -115907,10 +115913,10 @@ adY
 lSV
 xwu
 oNe
-aPh
+gjd
 nxh
 mTh
-dMy
+kuy
 jMW
 kWl
 aGm
@@ -116421,10 +116427,10 @@ aiB
 avc
 lft
 hXU
-qct
+fEy
 bvE
 hgX
-wca
+mhL
 oaO
 msQ
 ooY
@@ -117521,7 +117527,7 @@ ctL
 cuF
 bpG
 cwK
-cxH
+dNQ
 cyt
 czl
 mqO
@@ -121034,7 +121040,7 @@ bzx
 bzx
 bzx
 bzx
-cfa
+lpi
 oyx
 fZa
 hll

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -10304,7 +10304,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bBW" = (
@@ -10753,7 +10753,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "bSN" = (
@@ -17077,7 +17077,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "gyv" = (
@@ -42631,7 +42631,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xIZ" = (

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -7,8 +7,7 @@
 /area/hallway/primary/fore)
 "aae" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -145,8 +144,7 @@
 /area/crew_quarters/heads/cmo)
 "abJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -186,8 +184,7 @@
 /area/medical/medbay/central)
 "abU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -342,8 +339,7 @@
 /area/security/brig)
 "acW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -675,8 +671,7 @@
 /area/space)
 "aeZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -933,8 +928,7 @@
 /area/science/robotics/mechbay)
 "agR" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
-	dir = 8;
-	icon_state = "dpvent_map-2"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -1004,7 +998,6 @@
 /area/science/mixing)
 "ahl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -1054,7 +1047,6 @@
 /area/science/mixing)
 "ahv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -1149,7 +1141,6 @@
 "ahT" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Research Division Delivery";
 	req_access_txt = "47"
@@ -1218,7 +1209,6 @@
 "aim" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
-	icon_state = "mvalve_map-2";
 	name = "port to mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1248,7 +1238,6 @@
 "air" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
-	icon_state = "mvalve_map-2";
 	name = "mix to port"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1414,8 +1403,7 @@
 /area/science/mixing)
 "aiU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -1427,8 +1415,7 @@
 /area/science/robotics/lab)
 "aiX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -1498,8 +1485,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -1517,8 +1503,7 @@
 /area/hallway/primary/starboard)
 "ajj" = (
 /obj/machinery/computer/mecha{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -1583,8 +1568,7 @@
 /area/science/research)
 "ajK" = (
 /obj/machinery/computer/rdconsole{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -1600,8 +1584,7 @@
 /area/tcommsat/server)
 "ajP" = (
 /obj/machinery/computer/robotics{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -1616,12 +1599,10 @@
 /area/science/nanite)
 "ajW" = (
 /obj/machinery/computer/rdconsole/experiment{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
@@ -1635,8 +1616,7 @@
 /obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
@@ -2054,7 +2034,6 @@
 /obj/machinery/button/door{
 	id = "armory";
 	name = "Armory Shutters";
-	pixel_x = 0;
 	pixel_y = -26;
 	req_access_txt = "3"
 	},
@@ -2194,8 +2173,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/med_data/laptop{
-	dir = 4;
-	icon_state = "laptop"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -2203,9 +2181,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amF" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2273,8 +2249,7 @@
 /area/security/brig)
 "amM" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -2468,8 +2443,7 @@
 /obj/machinery/recharger,
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -2630,8 +2604,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/computer/shuttle/labor{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -2687,8 +2660,7 @@
 /area/security/processing)
 "aok" = (
 /obj/machinery/computer/security/labor{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -3080,8 +3052,7 @@
 	dir = 8
 	},
 /obj/machinery/gulag_item_reclaimer{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/flasher{
 	id = "PCell 2";
@@ -3232,8 +3203,7 @@
 /area/security/main)
 "apK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3318,8 +3288,7 @@
 /area/science/xenobiology)
 "aqh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3440,8 +3409,7 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3453,8 +3421,7 @@
 /area/security/prison)
 "ara" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -3467,8 +3434,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3724,8 +3690,7 @@
 /area/crew_quarters/kitchen)
 "ase" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -3756,8 +3721,7 @@
 /area/engine/engine_room)
 "asj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -3812,8 +3776,7 @@
 "asx" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -4133,9 +4096,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "atW" = (
@@ -4251,8 +4212,7 @@
 /area/chapel/main)
 "auS" = (
 /obj/structure/chair/pew/right{
-	dir = 4;
-	icon_state = "pewend_right"
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -4278,16 +4238,14 @@
 /area/chapel/main)
 "auV" = (
 /obj/structure/chair/pew/left{
-	dir = 4;
-	icon_state = "pewend_left"
+	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "auW" = (
 /obj/structure/chair/pew/left{
-	dir = 4;
-	icon_state = "pewend_left"
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -4441,8 +4399,7 @@
 /obj/item/aiModule/supplied/freeform,
 /obj/item/aiModule/supplied/quarantine,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -5367,7 +5324,6 @@
 /obj/structure/cable,
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 4;
-	icon_state = "telescreen";
 	pixel_x = -24
 	},
 /obj/machinery/computer/secure_data{
@@ -5501,15 +5457,13 @@
 /area/security/main)
 "aAO" = (
 /obj/machinery/atmospherics/components/binary/circulator/cold{
-	dir = 4;
-	icon_state = "circ-off-0"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "aAQ" = (
 /obj/machinery/atmospherics/components/binary/circulator{
-	dir = 8;
-	icon_state = "circ-off-0"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -5610,9 +5564,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -5673,9 +5625,7 @@
 /obj/item/clothing/glasses/meson{
 	pixel_y = 4
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aCq" = (
@@ -5712,8 +5662,7 @@
 /area/science/research)
 "aCH" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
-	dir = 4;
-	icon_state = "inje_map-2"
+	dir = 4
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -5733,8 +5682,7 @@
 /area/engine/atmos)
 "aCQ" = (
 /obj/machinery/computer/apc_control{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 4;
@@ -5808,8 +5756,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital/layer1{
-	dir = 8;
-	icon_state = "dvalve_map-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
@@ -5836,8 +5783,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1{
-	dir = 8;
-	icon_state = "scrub_map-1"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
@@ -5857,8 +5803,7 @@
 /area/hallway/primary/aft)
 "aDm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
-	dir = 4;
-	icon_state = "inje_map-2"
+	dir = 4
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
@@ -5925,8 +5870,7 @@
 /area/hallway/primary/aft)
 "aDz" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 4;
-	icon_state = "inje_map-2"
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -5955,8 +5899,7 @@
 /area/engine/atmos)
 "aDI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
-	dir = 4;
-	icon_state = "inje_map-2"
+	dir = 4
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
@@ -5973,8 +5916,7 @@
 /area/quartermaster/storage)
 "aDM" = (
 /obj/machinery/computer/atmos_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -5983,7 +5925,6 @@
 "aDN" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/layer3{
 	dir = 8;
-	icon_state = "dvalve_map-3";
 	name = "waste release"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -5993,8 +5934,7 @@
 /area/engine/atmos)
 "aDS" = (
 /obj/machinery/computer/atmos_control{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -6351,8 +6291,7 @@
 /area/engine/atmos)
 "aFo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
-	dir = 1;
-	icon_state = "connector_map-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -6366,8 +6305,7 @@
 "aFu" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -6398,15 +6336,13 @@
 "aFN" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aFP" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
-	dir = 8;
-	icon_state = "inje_map-2"
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -6559,8 +6495,7 @@
 /area/chapel/main)
 "aGG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1{
-	dir = 8;
-	icon_state = "scrub_map-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
@@ -7664,8 +7599,7 @@
 /area/engine/engine_room)
 "aLn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/computer/cargo,
 /obj/effect/turf_decal/tile/brown,
@@ -7676,8 +7610,7 @@
 /area/quartermaster/office)
 "aLo" = (
 /obj/machinery/computer/cargo/request{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -7689,8 +7622,7 @@
 /area/quartermaster/office)
 "aLy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown{
@@ -7803,8 +7735,7 @@
 /area/science/lab)
 "aMf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -8094,9 +8025,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aOk" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aOp" = (
@@ -8104,9 +8033,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aOq" = (
@@ -8137,8 +8064,7 @@
 /area/crew_quarters/locker)
 "aOz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -8247,9 +8173,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aPh" = (
@@ -8279,9 +8203,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "aPw" = (
@@ -8375,8 +8297,7 @@
 /area/science/research)
 "aQh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8538,8 +8459,7 @@
 /area/engine/lobby)
 "aRs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -8854,9 +8774,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aUj" = (
@@ -9344,8 +9262,7 @@
 "aYc" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -10248,8 +10165,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bxS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -10290,9 +10206,7 @@
 /area/crew_quarters/kitchen)
 "byM" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 2
-	},
+/obj/machinery/chem_dispenser/drinks,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -10390,6 +10304,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bBW" = (
@@ -10416,7 +10331,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Robotics Desk";
 	req_access_txt = "29"
@@ -10520,8 +10434,7 @@
 /area/maintenance/department/science)
 "bIJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -10840,6 +10753,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "bSN" = (
@@ -10894,8 +10808,7 @@
 /area/vacant_room/commissary)
 "bVe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -11033,9 +10946,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/wardrobe/miner,
@@ -11591,18 +11502,14 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "ctB" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "ctL" = (
@@ -11706,8 +11613,7 @@
 /area/hallway/primary/aft)
 "cxU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -11866,8 +11772,7 @@
 /area/library)
 "cFy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -11983,9 +11888,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/item/storage/box/bodybags,
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
@@ -12123,9 +12026,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cOO" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/crew_quarters/solgov)
 "cPk" = (
@@ -12491,9 +12392,7 @@
 	id = "crematoriumChapel";
 	pixel_x = 25
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dcM" = (
@@ -12739,8 +12638,7 @@
 /area/ai_monitored/turret_protected/ai)
 "dmg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -13145,9 +13043,7 @@
 "dDP" = (
 /obj/structure/table,
 /obj/item/crowbar,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "dDS" = (
@@ -13205,8 +13101,7 @@
 /area/medical/medbay/lobby)
 "dGR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -13356,8 +13251,7 @@
 /area/medical/virology)
 "dMq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -13376,9 +13270,7 @@
 /area/crew_quarters/theatre)
 "dOb" = (
 /obj/vehicle/ridden/janicart,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/janitor)
 "dOi" = (
@@ -13613,8 +13505,7 @@
 /area/quartermaster/miningoffice)
 "dVU" = (
 /obj/machinery/computer/rdconsole/production{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -13815,8 +13706,7 @@
 /area/hallway/secondary/service)
 "ecf" = (
 /obj/machinery/computer/scan_consolenew{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -13910,9 +13800,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "egW" = (
@@ -14000,8 +13888,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -14163,9 +14050,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -14235,9 +14120,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "epT" = (
@@ -14414,9 +14297,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "etW" = (
@@ -14468,9 +14349,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "evW" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
@@ -14856,9 +14735,7 @@
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "eHn" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -14871,9 +14748,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -14962,8 +14837,7 @@
 /area/storage/tech)
 "eMj" = (
 /obj/machinery/computer/prisoner/management{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15175,8 +15049,7 @@
 /area/crew_quarters/heads/hor)
 "eTT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -15281,9 +15154,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
 "eXa" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap{
 	pixel_x = -1;
@@ -15436,8 +15307,7 @@
 /area/security/brig)
 "fdS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -15670,8 +15540,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15864,9 +15733,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "fzN" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -16012,9 +15879,7 @@
 	},
 /obj/structure/closet/athletic_mixed,
 /obj/structure/closet/athletic_mixed,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -16193,9 +16058,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fHq" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -16282,9 +16145,7 @@
 /turf/open/space/basic,
 /area/solar/starboard/fore)
 "fKg" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
@@ -16674,9 +16535,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -16951,8 +16810,7 @@
 /area/science/lab)
 "gnK" = (
 /obj/machinery/computer/card/minor/ce{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -17012,9 +16870,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "gpf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -17022,8 +16878,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "gpO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/closet/cardboard,
 /obj/item/paper,
@@ -17160,9 +17015,7 @@
 	pixel_y = -8;
 	req_access_txt = "39"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17193,9 +17046,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -17226,6 +17077,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "gyv" = (
@@ -17343,8 +17195,7 @@
 /area/science/xenobiology)
 "gAS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -17407,7 +17258,6 @@
 /area/tcommsat/server)
 "gDb" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -17420,8 +17270,7 @@
 "gDe" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
-	dir = 1;
-	icon_state = "connector_map-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17512,9 +17361,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gFf" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -17528,9 +17375,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "gFP" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -17597,9 +17442,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -17671,9 +17514,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gLz" = (
@@ -17917,8 +17758,7 @@
 /area/medical/medbay/central)
 "gUX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -17941,9 +17781,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "gWu" = (
@@ -18274,8 +18112,7 @@
 /area/security/processing)
 "hhB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
@@ -18576,9 +18413,7 @@
 	dir = 10
 	},
 /obj/machinery/camera/autoname,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "hqX" = (
@@ -18810,8 +18645,7 @@
 /area/quartermaster/warehouse)
 "hyb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19002,8 +18836,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/modular_computer/console/preset/research{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
@@ -19113,8 +18946,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19258,9 +19090,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "hRC" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -19293,8 +19123,7 @@
 /area/hallway/primary/starboard)
 "hSN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -19432,9 +19261,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/purple{
@@ -19478,8 +19305,7 @@
 	c_tag = "Mining Dock"
 	},
 /obj/machinery/computer/security/mining{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -19530,8 +19356,7 @@
 /area/lawoffice)
 "iat" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hallway";
@@ -19608,8 +19433,7 @@
 "iey" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
-	dir = 4;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/atmos/plasma,
 /turf/open/floor/engine/plasma,
@@ -19711,9 +19535,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
 "ihH" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/structure/sink{
 	pixel_y = 17
 	},
@@ -20017,8 +19839,7 @@
 /area/medical/virology)
 "iwY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -20613,8 +20434,7 @@
 "iOx" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3{
-	dir = 1;
-	icon_state = "connector_map-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21318,9 +21138,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jlt" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jlx" = (
@@ -21849,9 +21667,7 @@
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "jFx" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21938,9 +21754,7 @@
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jKi" = (
@@ -22008,9 +21822,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jKR" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/solgov)
 "jLj" = (
@@ -22077,9 +21889,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "jOD" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "jPg" = (
@@ -22104,9 +21914,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jQd" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -22607,9 +22415,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kdn" = (
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "kdp" = (
@@ -22709,9 +22515,7 @@
 /area/tcommsat/server)
 "khU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
@@ -23052,9 +22856,7 @@
 /area/crew_quarters/bar)
 "kxz" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 2
-	},
+/obj/machinery/chem_dispenser/drinks/beer,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -23287,9 +23089,7 @@
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "kNj" = (
@@ -23622,8 +23422,7 @@
 /area/hallway/secondary/entry)
 "kVL" = (
 /obj/machinery/computer/cargo/request{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -23636,16 +23435,13 @@
 /area/science/lab)
 "kXd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
-	dir = 4;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/atmos/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "kXn" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "kXr" = (
@@ -24064,8 +23860,7 @@
 /area/science/research)
 "lhc" = (
 /obj/machinery/sleeper{
-	dir = 1;
-	icon_state = "sleeper"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -24117,9 +23912,7 @@
 	dir = 4;
 	pixel_x = -31
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "lie" = (
@@ -24367,9 +24160,7 @@
 /area/hallway/primary/starboard)
 "lsP" = (
 /obj/structure/chair,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/newscaster{
 	dir = 1;
 	pixel_y = 30
@@ -24384,8 +24175,7 @@
 /area/engine/engine_room)
 "ltO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral,
@@ -24397,8 +24187,7 @@
 /area/medical/medbay/central)
 "luQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -24467,8 +24256,7 @@
 /area/maintenance/department/electrical)
 "lAj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -24516,9 +24304,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "lBO" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -25104,8 +24890,7 @@
 /area/science/xenobiology)
 "lWI" = (
 /obj/machinery/computer/cloning{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -25118,9 +24903,7 @@
 /area/medical/genetics/cloning)
 "lXh" = (
 /obj/machinery/recharge_station,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "lXv" = (
@@ -25234,8 +25017,7 @@
 /area/quartermaster/office)
 "mcs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
-	dir = 4;
-	icon_state = "vent_map_siphon_on-2"
+	dir = 4
 	},
 /obj/effect/turf_decal/atmos/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -25328,9 +25110,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
 	dir = 4
@@ -25610,9 +25390,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "mpJ" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -25762,8 +25540,7 @@
 /area/maintenance/department/electrical)
 "mvo" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -25806,8 +25583,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -25901,8 +25677,7 @@
 /area/library)
 "mxO" = (
 /obj/machinery/computer/cargo{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27228,9 +27003,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "noy" = (
@@ -27364,8 +27137,7 @@
 /area/ai_monitored/security/armory)
 "nug" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
@@ -27522,7 +27294,6 @@
 /area/engine/atmos)
 "nxn" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -27700,9 +27471,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/engine/lobby)
 "nAi" = (
@@ -27854,9 +27623,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -27934,9 +27701,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -28033,9 +27798,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -28063,9 +27826,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "nMc" = (
@@ -28353,8 +28114,7 @@
 /area/library)
 "nVm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28458,9 +28218,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "nXv" = (
@@ -29427,9 +29185,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "oCt" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -29701,9 +29457,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "oKG" = (
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "oKO" = (
@@ -29762,12 +29516,10 @@
 /area/ai_monitored/turret_protected/ai)
 "oLx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/computer/cargo/request{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
@@ -29977,8 +29729,7 @@
 /area/medical/medbay/lobby)
 "oVP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -30116,9 +29867,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/security/main)
 "pbL" = (
@@ -30531,9 +30280,7 @@
 	pixel_y = -8
 	},
 /obj/machinery/computer/security,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pmD" = (
@@ -30645,15 +30392,13 @@
 "psF" = (
 /obj/machinery/computer/operating{
 	dir = 8;
-	icon_state = "computer";
 	name = "Robotics Operating Computer"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -31130,8 +30875,7 @@
 /area/hallway/primary/central)
 "pJf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31254,9 +30998,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pNZ" = (
@@ -31302,9 +31044,7 @@
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
 "pPJ" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "pQj" = (
@@ -31806,8 +31546,7 @@
 /area/crew_quarters/bar)
 "qgW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -31928,9 +31667,7 @@
 /area/maintenance/disposal)
 "qkN" = (
 /obj/machinery/teleport/station,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "qlo" = (
@@ -32101,8 +31838,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -32136,8 +31872,7 @@
 /area/maintenance/port/fore)
 "qta" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32258,8 +31993,7 @@
 /area/hallway/secondary/service)
 "qAg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -32519,9 +32253,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qMS" = (
@@ -32818,15 +32550,12 @@
 /area/medical/genetics)
 "qUo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/security/execution/education)
 "qWb" = (
@@ -32853,9 +32582,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -33026,9 +32753,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
@@ -33094,9 +32819,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "rhy" = (
@@ -33941,9 +33664,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -34340,9 +34061,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "rWG" = (
@@ -34370,9 +34089,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "rWU" = (
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -34432,9 +34149,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rZp" = (
@@ -34458,8 +34173,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -34605,8 +34319,7 @@
 /area/science/research)
 "seD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/plasteel,
@@ -34858,9 +34571,7 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "spq" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -34889,9 +34600,7 @@
 	pixel_y = 26
 	},
 /obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "spW" = (
@@ -35064,8 +34773,7 @@
 /area/crew_quarters/heads/chief)
 "svN" = (
 /obj/structure/chair/pew/left{
-	dir = 4;
-	icon_state = "pewend_left"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35971,19 +35679,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tbo" = (
 /obj/machinery/computer/bounty{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35992,7 +35696,6 @@
 /area/crew_quarters/heads/head_of_personnel)
 "tbz" = (
 /obj/machinery/door/window{
-	dir = 2;
 	icon_state = "rightsecure";
 	name = "Theatre Stage"
 	},
@@ -36291,8 +35994,7 @@
 /area/engine/atmos)
 "thX" = (
 /obj/machinery/computer/security{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -36566,9 +36268,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/security/main)
 "tpA" = (
@@ -36652,15 +36352,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "twc" = (
 /obj/structure/chair/pew/right{
-	dir = 4;
-	icon_state = "pewend_right"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36674,8 +36371,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -36714,8 +36410,7 @@
 /area/maintenance/department/electrical)
 "tzb" = (
 /obj/machinery/modular_computer/console/preset/engineering{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -36757,8 +36452,7 @@
 /area/engine/atmos)
 "tAU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/open/floor/plasteel/white,
@@ -36782,8 +36476,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "tCe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
@@ -37120,8 +36813,7 @@
 "tSE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -37193,8 +36885,7 @@
 /area/quartermaster/office)
 "tUq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -37317,9 +37008,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -27
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/crew_quarters/solgov)
 "tZb" = (
@@ -37572,8 +37261,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -37762,9 +37450,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/library)
@@ -37877,9 +37563,7 @@
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "unN" = (
@@ -38003,8 +37687,7 @@
 /area/crew_quarters/toilet/restrooms)
 "utU" = (
 /obj/machinery/computer/cargo/request{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -38036,8 +37719,7 @@
 /area/vacant_room/commissary)
 "uuQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -38323,9 +38005,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/item/shovel/spade,
 /obj/item/wirecutters,
 /obj/item/wrench,
@@ -38497,18 +38177,14 @@
 /obj/structure/window/reinforced,
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "uJU" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -38534,12 +38210,9 @@
 /obj/item/radio/off,
 /obj/item/book/manual/wiki/tcomms,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "uLl" = (
@@ -38556,9 +38229,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "uLT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "uMe" = (
@@ -38608,9 +38279,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "uNz" = (
@@ -38654,15 +38323,12 @@
 /area/quartermaster/storage)
 "uOh" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "uOw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38740,8 +38406,7 @@
 /area/quartermaster/sorting)
 "uQH" = (
 /obj/machinery/computer/security{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -38888,9 +38553,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "uWx" = (
-/obj/structure/chair/office/light{
-	dir = 2
-	},
+/obj/structure/chair/office/light,
 /obj/machinery/button/door{
 	id = "chemistry_shutters";
 	name = "Chemistry shutters";
@@ -39012,9 +38675,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -39148,9 +38809,7 @@
 	},
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/assembly/signaler,
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "vbL" = (
@@ -39280,8 +38939,7 @@
 /area/tcommsat/computer)
 "vfM" = (
 /obj/machinery/computer/prisoner/management{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -39314,8 +38972,7 @@
 "vgk" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/solgov)
@@ -39342,8 +38999,7 @@
 /area/crew_quarters/fitness/recreation)
 "viv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/yellow{
@@ -39381,8 +39037,7 @@
 /area/hallway/primary/fore)
 "vlL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -39506,8 +39161,7 @@
 /area/space/nearstation)
 "vqf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39740,8 +39394,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/solgov)
@@ -39749,9 +39402,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -39952,15 +39603,13 @@
 /area/chapel/main)
 "vEx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "vEV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -40018,9 +39667,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -40292,8 +39939,7 @@
 /area/maintenance/starboard/central)
 "vYC" = (
 /obj/machinery/computer/atmos_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -40600,16 +40246,13 @@
 "wkg" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/item/clothing/under/rank/security/officer/mallcop,
 /turf/open/floor/plasteel,
 /area/security/main)
 "wkE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -40737,8 +40380,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	pixel_y = -32
@@ -40945,9 +40587,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/security/main)
 "wxN" = (
@@ -41011,9 +40651,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "wAZ" = (
@@ -41191,8 +40829,7 @@
 /area/hallway/secondary/entry)
 "wFf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -41432,9 +41069,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wJZ" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -41550,9 +41185,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wNP" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "wOj" = (
@@ -41712,9 +41345,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/computer/med_data{
-	icon_state = "computer"
-	},
+/obj/machinery/computer/med_data,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -42225,9 +41856,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xjy" = (
@@ -42431,9 +42060,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
 "xrO" = (
@@ -42618,8 +42245,7 @@
 /area/medical/pharmacy)
 "xxH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	icon_state = "vent_map-2"
+	dir = 1
 	},
 /obj/structure/table,
 /obj/item/clothing/glasses/hud/health,
@@ -42783,9 +42409,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -43007,6 +42631,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xIZ" = (
@@ -43049,9 +42674,7 @@
 	departmentType = 5;
 	pixel_y = -32
 	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
 "xKB" = (
@@ -43309,8 +42932,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/requests_console{
 	department = "Bar";

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -983,21 +983,6 @@
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/circuit,
 /area/science/lab)
-"ahZ" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aia" = (
 /obj/machinery/light{
 	dir = 1
@@ -1576,22 +1561,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/lab)
-"alD" = (
-/obj/machinery/nanite_program_hub,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "alF" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -5525,13 +5494,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"aQm" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
 "aQn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5694,15 +5656,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"aRr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "aRt" = (
 /obj/structure/chair/office/light{
 	dir = 8;
@@ -6027,6 +5980,13 @@
 "aTj" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
+"aTn" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aTo" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -7302,6 +7262,37 @@
 "bhc" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
+"bhA" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bhQ" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
@@ -8397,6 +8388,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cga" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cgb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -8528,6 +8546,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"clj" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "clC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9262,6 +9284,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cNX" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "cPs" = (
 /obj/machinery/requests_console{
 	department = "AI";
@@ -10615,36 +10645,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dVg" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dVh" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
@@ -11279,12 +11279,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"etf" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "etR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -12305,13 +12299,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"fhh" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "fiG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12689,32 +12676,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"ftF" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fuk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/event_spawn,
@@ -12739,6 +12700,15 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"fuK" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -12918,18 +12888,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"fBy" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "fCg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14256,15 +14214,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"gFW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "gHf" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/delivery,
@@ -14755,6 +14704,36 @@
 /obj/item/clothing/mask/balaclava,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hbT" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hbZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -14777,14 +14756,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hdd" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "hdh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14931,13 +14902,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"hhZ" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hii" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15731,6 +15695,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hMe" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 10;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/large;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "hMs" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
@@ -16801,6 +16777,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"iBC" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iBP" = (
 /obj/machinery/airalarm/server{
 	dir = 8;
@@ -17191,6 +17178,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"iUM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "iWb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17688,17 +17684,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"jqQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
+"jqR" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "jrc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17884,6 +17876,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jyn" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "jys" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -19151,13 +19151,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kDF" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/westleft{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "kDH" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/air_sensor/atmos/oxygen_tank,
@@ -20175,6 +20168,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lsu" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lsB" = (
 /obj/machinery/firealarm{
 	pixel_y = -26
@@ -20430,6 +20430,21 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lDD" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -20813,6 +20828,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lSK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "lST" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/bar)
@@ -20892,6 +20916,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/sleeper)
+"lXn" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "lXQ" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -20927,6 +20963,43 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lZe" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lZf" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -21673,17 +21746,6 @@
 /obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"mAe" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "mAj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22220,18 +22282,6 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/medbay/central)
-"mVK" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 10;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/large;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "mWh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -24624,18 +24674,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"oLj" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "oMa" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 2"
@@ -26842,35 +26880,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"qAd" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qAp" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -27434,21 +27443,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qXt" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "qXu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -27921,13 +27915,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rsX" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "rtb" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
@@ -28023,6 +28010,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"rvN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "rwK" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel,
@@ -28152,10 +28148,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"rCW" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "rDt" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -28292,15 +28284,6 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"rLE" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "rMg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -28768,6 +28751,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"scS" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "sdz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28928,42 +28926,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"smj" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "smp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -29395,6 +29357,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"sBD" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "sBF" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=ESC";
@@ -29776,6 +29750,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"sWd" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "sWr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33102,6 +33087,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"vGx" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vHX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -33486,6 +33478,22 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/space)
+"wbl" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "wbm" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -33980,6 +33988,13 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"wwj" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wxn" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -34043,6 +34058,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"wAz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wBx" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/structure/window/reinforced{
@@ -34150,15 +34176,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wGX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "wIk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -34400,17 +34417,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"wSo" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "wSD" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/neutral,
@@ -62051,7 +62057,7 @@ kXm
 yhW
 hNH
 mXZ
-rLE
+fuK
 kVC
 nYm
 vWL
@@ -62534,7 +62540,7 @@ ajd
 ajd
 ajd
 ajd
-mVK
+hMe
 ajd
 ajd
 ajd
@@ -62791,7 +62797,7 @@ ajd
 ajd
 adS
 hwc
-oLj
+sBD
 hwc
 adS
 ajd
@@ -63048,7 +63054,7 @@ ajd
 ajd
 hwc
 aIj
-aRr
+iUM
 sxN
 adS
 ajd
@@ -63305,13 +63311,13 @@ abq
 adS
 adS
 adS
-qXt
+scS
 aQU
 adS
 adS
 akf
 aWS
-hhZ
+wwj
 rWE
 xuC
 qCX
@@ -63562,7 +63568,7 @@ kSU
 fpd
 xez
 bhQ
-gFW
+rvN
 saT
 qjP
 aKv
@@ -63818,8 +63824,8 @@ qAq
 efO
 lMP
 xYG
-mAe
-wGX
+sWd
+lSK
 acW
 aWr
 adS
@@ -64061,7 +64067,7 @@ aGa
 ajd
 rfw
 rAW
-aQm
+jqR
 axB
 aln
 nDQ
@@ -64848,7 +64854,7 @@ abq
 abq
 yfu
 eci
-wSo
+iBC
 wQx
 dcT
 lkw
@@ -65123,7 +65129,7 @@ azg
 iYo
 pwn
 aso
-etf
+vGx
 auW
 cFa
 aXJ
@@ -65894,7 +65900,7 @@ qmd
 jrI
 mbJ
 gOG
-kDF
+cNX
 aCn
 ajz
 kwz
@@ -67685,7 +67691,7 @@ atr
 qho
 xII
 pAW
-jqQ
+wAz
 fFx
 xOu
 nZL
@@ -68219,7 +68225,7 @@ hKY
 kIt
 ufS
 qMR
-fhh
+aTn
 wDI
 qMR
 cAn
@@ -68690,7 +68696,7 @@ ogQ
 mKO
 kug
 waj
-fBy
+lXn
 waj
 bib
 waj
@@ -68739,7 +68745,7 @@ ygQ
 pmZ
 isJ
 uLh
-ahZ
+lDD
 oKY
 kyg
 ebB
@@ -68952,8 +68958,8 @@ acj
 acj
 acj
 aTx
-dVg
-smj
+bhA
+lZe
 acj
 skL
 skL
@@ -69723,8 +69729,8 @@ quT
 acj
 ehN
 aoR
-ftF
-qAd
+cga
+hbT
 ack
 aos
 ixs
@@ -77686,7 +77692,7 @@ ajd
 ajd
 ajd
 agV
-alD
+wbl
 hCf
 aYK
 wZp
@@ -79015,7 +79021,7 @@ atN
 aim
 pYh
 crK
-rsX
+lsu
 ahg
 vgF
 rTO
@@ -80292,7 +80298,7 @@ aHM
 acJ
 hRJ
 tIq
-hdd
+jyn
 pYh
 ecG
 pYh
@@ -80545,7 +80551,7 @@ acJ
 aqI
 sSb
 aqI
-rCW
+clj
 aFJ
 rTO
 rTO

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3738,6 +3738,18 @@
 /obj/item/clothing/under/color/red,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aqk" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 10;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/kilo;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "aqn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -8024,24 +8036,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"aHh" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Head of Personnel's Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aHl" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "foqueue";
-	name = "Head of Personnel's Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHr" = (
 /obj/machinery/shower{
@@ -13510,17 +13504,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bcG" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bcN" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -13690,15 +13673,6 @@
 /obj/item/pen,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bdL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -14064,22 +14038,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"beP" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"beS" = (
-/obj/item/caution,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "beY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Central";
@@ -14290,17 +14248,6 @@
 /area/quartermaster/miningdock)
 "bfG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bfH" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/computer/security/mining{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19329,6 +19276,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"bAn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27931,16 +27887,6 @@
 "cjv" = (
 /turf/closed/wall,
 /area/asteroid/nearstation/bomb_site)
-"cjw" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/indestructible/riveted{
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
-	name = "hyper-reinforced wall"
-	},
-/area/asteroid/nearstation/bomb_site)
 "cjx" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
@@ -28711,12 +28657,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation/bomb_site)
-"cnq" = (
-/turf/closed/indestructible/riveted{
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
-	name = "hyper-reinforced wall"
-	},
 /area/asteroid/nearstation/bomb_site)
 "cnr" = (
 /obj/structure/table,
@@ -29939,19 +29879,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/mineral/iron,
 /area/chapel/main/monastery)
-"ctA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "ctJ" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
@@ -31928,6 +31855,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"cSk" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "cSB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/button/door{
@@ -32038,6 +31977,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cUl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "cVC" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -32617,13 +32571,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
-"doK" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "dpb" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -32661,6 +32608,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"dpu" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/computer/security/mining{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "dpM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -35015,29 +34973,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"eNz" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eNF" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -35331,7 +35266,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"faW" = (
+"fat" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -35347,6 +35282,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fbm" = (
@@ -38059,6 +37995,21 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"gFI" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/shaft_miner,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "gFJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -39189,26 +39140,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"hse" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hsK" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -39700,19 +39631,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/chapel/main/monastery)
-"hNF" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "hNG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40562,6 +40480,13 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"ino" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "inu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -42081,6 +42006,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"jmB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "jmE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc/highcap/ten_k{
@@ -42639,6 +42577,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jGG" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/indestructible/riveted{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	name = "hyper-reinforced wall"
+	},
+/area/asteroid/nearstation/bomb_site)
 "jHl" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -43010,31 +42958,6 @@
 /obj/item/stack/ore/iron,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"jXJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jXV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -43266,6 +43189,19 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"khR" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "khT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -44744,6 +44680,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"laU" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "lbl" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/machinery/status_display/evac{
@@ -44812,6 +44761,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ldb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "ldd" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -45158,6 +45115,15 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"lqm" = (
+/obj/item/caution,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "lqE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -45682,6 +45648,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"lKw" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Head of Personnel's Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lKB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
@@ -46556,6 +46533,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
+"mvD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "foqueue";
+	name = "Head of Personnel's Queue Shutters"
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mvM" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room";
@@ -46837,18 +46823,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"mEw" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "mEE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -47115,15 +47089,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"mNL" = (
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "mOC" = (
 /obj/item/broken_bottle,
 /obj/structure/cable{
@@ -50706,6 +50671,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"oXb" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/requests_console{
+	department = "Mining";
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "oXe" = (
 /obj/structure/table/glass,
 /obj/item/mmi,
@@ -50873,6 +50847,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pdc" = (
+/turf/closed/indestructible/riveted{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	name = "hyper-reinforced wall"
+	},
+/area/asteroid/nearstation/bomb_site)
 "pdl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -51167,6 +51147,15 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"pqJ" = (
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "pqN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51434,6 +51423,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"pDM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -52261,18 +52263,6 @@
 	},
 /turf/open/space,
 /area/solar/starboard)
-"qhm" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 10;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/kilo;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "qhL" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "AI Core";
@@ -52462,6 +52452,17 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"qph" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "qpr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52639,6 +52640,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
+"quM" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/computer/security/mining{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "qwK" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "AI Core";
@@ -53460,6 +53468,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"rcG" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rdy" = (
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
@@ -54114,18 +54143,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rCo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "rCP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -54157,21 +54174,6 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rEj" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "rFd" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -55314,19 +55316,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"spn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -55523,6 +55512,32 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"swy" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sxT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -56857,21 +56872,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"tpq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "tpt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -57730,6 +57730,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"tVM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tVT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -58558,14 +58570,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uoC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "uoN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -61529,15 +61533,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wgo" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/requests_console{
-	department = "Mining";
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "wgB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -61801,19 +61796,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall,
 /area/science/mixing)
-"wnX" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "woq" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -64211,6 +64193,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xOz" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/scanner_gate,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xPa" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -88638,10 +88644,10 @@ amg
 aqv
 fOs
 asw
-eNz
+xOz
 jvc
 wfP
-jXJ
+swy
 axK
 ayM
 aAj
@@ -89152,10 +89158,10 @@ agP
 aqx
 jqN
 asD
-faW
+fat
 auC
 auC
-hse
+rcG
 axL
 ayO
 aAl
@@ -97903,7 +97909,7 @@ jlw
 pHo
 aAH
 aGu
-aHh
+lKw
 aHV
 aDZ
 aJV
@@ -99188,7 +99194,7 @@ ygS
 vrI
 jSG
 aGx
-aHl
+mvD
 aHV
 aDZ
 aJV
@@ -105634,7 +105640,7 @@ aZs
 kXh
 gRr
 fad
-rEj
+gFI
 cnR
 bDj
 twc
@@ -105891,7 +105897,7 @@ aZt
 aZp
 nOn
 bcF
-bdL
+bAn
 beO
 bfG
 bgM
@@ -106147,11 +106153,11 @@ aYB
 cCT
 baF
 bbI
-bcG
-doK
-beP
-bfH
-wgo
+qph
+ino
+quM
+dpu
+oXb
 bhv
 bbI
 aEj
@@ -106405,7 +106411,7 @@ aLg
 aLg
 bbI
 bdI
-wnX
+khR
 bdI
 bbI
 bbI
@@ -106662,7 +106668,7 @@ aaa
 aaa
 aaa
 lJD
-mNL
+pqJ
 lJD
 aaa
 aaa
@@ -106919,7 +106925,7 @@ aaa
 aaa
 aaa
 lJD
-hNF
+laU
 lJD
 aaa
 aaa
@@ -107176,7 +107182,7 @@ aaa
 aaa
 aaa
 aaa
-qhm
+aqk
 aaa
 aaa
 aaa
@@ -108526,7 +108532,7 @@ aaa
 aaa
 abI
 ahi
-cjw
+jGG
 cjV
 ckt
 cjx
@@ -108722,7 +108728,7 @@ aaa
 aaa
 aaa
 aEj
-mEw
+cSk
 aEU
 kje
 kLV
@@ -108979,7 +108985,7 @@ aaa
 aaa
 aaa
 wpf
-rCo
+tVM
 aEj
 bkF
 bkF
@@ -109077,7 +109083,7 @@ ckK
 cju
 cjx
 cnp
-cnq
+pdc
 cju
 cju
 aaa
@@ -109236,7 +109242,7 @@ aaa
 aaa
 aaa
 aEj
-tpq
+cUl
 lEn
 pnU
 pnU
@@ -109493,7 +109499,7 @@ aEj
 wpf
 wpf
 aEj
-ctA
+jmB
 lEn
 uwb
 bjB
@@ -109554,7 +109560,7 @@ aaa
 aaa
 abI
 ahi
-cjw
+jGG
 cjx
 cjx
 ckt
@@ -109746,11 +109752,11 @@ wNT
 kje
 mYn
 kje
-uoC
-beS
-uoC
-uoC
-spn
+ldb
+lqm
+ldb
+ldb
+pDM
 lEn
 biD
 biD

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35282,7 +35282,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fbm" = (
@@ -45656,7 +45656,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lKB" = (
@@ -46539,7 +46539,7 @@
 	name = "Head of Personnel's Queue Shutters"
 	},
 /obj/effect/turf_decal/loading_area,
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/hop,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mvM" = (
@@ -53486,7 +53486,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rdy" = (
@@ -55535,7 +55534,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/scanner_gate,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sxT" = (
@@ -64214,7 +64212,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/scanner_gate,
+/obj/machinery/scanner_gate/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xPa" = (

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3246,6 +3246,7 @@
 #include "whitesands\code\game\machinery\cloning.dm"
 #include "whitesands\code\game\machinery\cryopod.dm"
 #include "whitesands\code\game\machinery\exp_cloner.dm"
+#include "whitesands\code\game\machinery\scan_gate.dm"
 #include "whitesands\code\game\machinery\Sleeper.dm"
 #include "whitesands\code\game\machinery\suit_storage_unit.dm"
 #include "whitesands\code\game\machinery\computer\cloning.dm"

--- a/whitesands/code/game/machinery/scan_gate.dm
+++ b/whitesands/code/game/machinery/scan_gate.dm
@@ -1,5 +1,25 @@
+#define SCANGATE_NONE 			"Off"
+#define SCANGATE_MINDSHIELD 	"Mindshield"
+#define SCANGATE_NANITES 		"Nanites"
+#define SCANGATE_DISEASE 		"Disease"
+#define SCANGATE_GUNS 			"Guns"
+#define SCANGATE_WANTED			"Wanted"
+#define SCANGATE_SPECIES		"Species"
+#define SCANGATE_NUTRITION		"Nutrition"
+
 /obj/machinery/scanner_gate/sec
 	req_access = list(ACCESS_BRIG)
+	scangate_mode = SCANGATE_WANTED
 
 /obj/machinery/scanner_gate/hop
 	req_access = list(ACCESS_HOP)
+	scangate_mode = SCANGATE_GUNS
+
+#undef SCANGATE_NONE
+#undef SCANGATE_MINDSHIELD
+#undef SCANGATE_NANITES
+#undef SCANGATE_DISEASE
+#undef SCANGATE_GUNS
+#undef SCANGATE_WANTED
+#undef SCANGATE_SPECIES
+#undef SCANGATE_NUTRITION

--- a/whitesands/code/game/machinery/scan_gate.dm
+++ b/whitesands/code/game/machinery/scan_gate.dm
@@ -1,0 +1,5 @@
+/obj/machinery/scanner_gate/sec
+	req_access = list(ACCESS_BRIG)
+
+/obj/machinery/scanner_gate/hop
+	req_access = list(ACCESS_HOP)


### PR DESCRIPTION
## About The Pull Request

title

the only other place where scanner gates seem to be used is on the luxury shuttle so ya

**wiki change recommended**

## Why It's Good For The Game

a good rule of note as the hop is that 1 out of 3 people who come up to you for an access change are going to use it maliciously

## Changelog
:cl:
add: added scanner gates to hop and brig, dont forget to calibrate them
/:cl: