### PR TITLE
The Bar and Kitchen update for Meta that no one asked for

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21615,17 +21615,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bLM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -25634,6 +25623,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cdF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_x = -4;
+	pixel_y = 28;
+	req_access_txt = "28"
+	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "cdG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -50639,16 +50648,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"hZT" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_z = -28
-	},
-/obj/structure/table,
-/obj/item/camera,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "iau" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52016,6 +52015,15 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"iIC" = (
+/obj/structure/table,
+/obj/item/camera,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "iIG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -53571,23 +53579,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"juI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Kitchen Shutters Control";
-	pixel_x = -4;
-	pixel_y = 28;
-	req_access_txt = "28"
-	},
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "juM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -87670,6 +87661,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"yhD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "yih" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -121333,7 +121332,7 @@ bkU
 bmM
 dGZ
 hXM
-hZT
+iIC
 bmP
 iIL
 rUn
@@ -121858,7 +121857,7 @@ izV
 byC
 mvE
 pYv
-bLM
+yhD
 bNx
 xKg
 hPW
@@ -122115,7 +122114,7 @@ nsK
 sqV
 vaP
 bKe
-juI
+cdF
 bNx
 cpu
 tIn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75,32 +75,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"aao" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "aaq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
-"aat" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aav" = (
 /turf/open/space,
 /area/space)
@@ -147,28 +125,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaF" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"aaL" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"aaM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aaO" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
@@ -369,31 +325,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"abP" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/rag{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "abR" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
-"abS" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/photo_album/bar,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "abU" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4581,6 +4516,18 @@
 /obj/machinery/computer/shuttle/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"ara" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/kitchen/coldroom";
+	dir = 1;
+	name = "Kitchen Cold Room APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "arh" = (
 /obj/item/reagent_containers/glass/bottle/toxin{
 	pixel_x = 4;
@@ -6512,22 +6459,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aAs" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Club"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aAt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -8326,6 +8257,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"aID" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/item/clothing/head/that,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "aIK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -12675,6 +12615,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aYZ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "aZq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -16063,19 +16012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bkX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bkY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17077,16 +17013,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"boK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "boL" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17097,24 +17023,6 @@
 "boP" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"boQ" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"boR" = (
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/machinery/camera{
-	c_tag = "Bar - Backroom"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 28
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -17153,13 +17061,6 @@
 "boV" = (
 /obj/item/storage/box/lights/mixed,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"boX" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "boY" = (
@@ -17561,14 +17462,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"bra" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "brc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -17579,17 +17472,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"brf" = (
-/obj/structure/table,
-/obj/item/paper_bin/construction,
-/obj/item/airlock_painter,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/rcl/pre_loaded,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "brg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17612,19 +17494,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"brk" = (
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "brm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17634,15 +17503,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"brn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -18110,40 +17970,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"bto" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "btp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"btq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/item/wrench,
-/obj/item/stack/sheet/glass{
-	amount = 30
-	},
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/structure/closet,
-/obj/item/vending_refill/cigarette,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"btr" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe";
-	pixel_x = -4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -18433,38 +18264,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"buP" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"buQ" = (
-/obj/machinery/vending/classicbeats,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"buS" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"buT" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "buU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -18858,11 +18657,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bwW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bwX" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -19140,22 +18934,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"byy" = (
-/obj/effect/landmark/start/bartender,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"byz" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/mob/living/carbon/monkey/punpun,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "byA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/start/bartender,
@@ -19166,41 +18944,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "byC" = (
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"byE" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"byF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"byG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"byH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "byI" = (
@@ -19642,99 +19385,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"bAi" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAj" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAk" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAl" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAn" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAo" = (
-/obj/machinery/smartfridge/drinks{
-	icon_state = "boozeomat"
-	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"bAq" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/lootdrop/gambling,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bAr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bAs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"bAp" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bAt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -19925,12 +19587,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"bBj" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "bBn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -20067,32 +19723,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"bBT" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bBU" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bBV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bBW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20107,20 +19737,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"bBY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bBZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "bCa" = (
 /obj/structure/chair/wood/wings,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20505,14 +20121,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bDD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"bDC" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "bDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/bar,
@@ -20526,12 +20142,6 @@
 	pixel_y = 8
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bDJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/wood/poker,
-/obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bDK" = (
@@ -20710,6 +20320,15 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"bED" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "bFp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20742,25 +20361,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bFu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bFv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "bFw" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -21047,51 +20647,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bGY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"bGZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bHa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bHb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bHc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bHd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -21350,59 +20905,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"bIs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bIt" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "bIv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"bIw" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Kitchen Hatch";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bIx" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"bIA" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/light,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"bIB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "bIC" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -21745,41 +21259,6 @@
 "bKe" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
-"bKh" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
-"bKl" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"bKm" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"bKn" = (
-/obj/machinery/camera{
-	c_tag = "Club - Aft";
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -29
-	},
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"bKo" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"bKp" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "bKr" = (
 /turf/closed/wall/r_wall,
 /area/storage/tcom)
@@ -22128,14 +21607,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bLI" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
 "bLK" = (
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -22153,15 +21624,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bLN" = (
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -22383,15 +21845,6 @@
 /obj/machinery/libraryscanner,
 /turf/open/floor/wood,
 /area/library)
-"bMP" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bMR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -22526,6 +21979,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"bNj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bNl" = (
 /turf/closed/wall,
 /area/gateway)
@@ -22593,25 +22055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bNu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bNv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bNx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22620,17 +22063,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bNF" = (
-/obj/machinery/gibber,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
-"bNG" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "bNI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -22895,31 +22327,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bOP" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bOS" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bOT" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "bOX" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -22933,20 +22340,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bOZ" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -4
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
-"bPa" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "bPb" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -23303,20 +22696,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bQI" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
-"bQJ" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "bQN" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -23530,35 +22909,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/gateway)
-"bRQ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"bRR" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "kitchenhydro";
-	name = "Service Shutter Control";
-	pixel_x = 7;
-	pixel_y = -24;
-	req_access_txt = "28"
-	},
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bRS" = (
-/obj/machinery/deepfryer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bSd" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
@@ -23901,37 +23251,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bUc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bUd" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/sign/departments/botany{
-	pixel_x = 32;
-	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25308,11 +24627,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bZx" = (
-/obj/machinery/icecream_vat,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "bZA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -26646,7 +25960,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cfa" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "cfq" = (
@@ -27400,20 +26716,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"chZ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "cia" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -31171,13 +30473,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
-"cvB" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "cvC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -31847,7 +31142,9 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "cxH" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -31864,6 +31161,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cxN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Kitchen Cold Room";
+	req_access_txt = "28"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "cxP" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -37620,16 +36943,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"cUp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "cUH" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
@@ -37776,6 +37089,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"cWI" = (
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cWK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38147,10 +37467,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dbd" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "dbe" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 26
@@ -39543,29 +38859,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
-"dhT" = (
-/obj/structure/sign/poster/random,
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"dhU" = (
-/obj/structure/musician/piano,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"dhV" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "dhW" = (
 /obj/structure/table/wood,
 /obj/item/staff/broom,
@@ -39640,18 +38933,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
-"dii" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Theatre Stage"
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "dij" = (
 /obj/item/instrument/violin,
 /obj/structure/table/wood,
@@ -39663,16 +38944,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"dik" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dil" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -40409,22 +39680,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dqz" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/bar";
-	dir = 1;
-	name = "Bar APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -27
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "dqH" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
@@ -40502,6 +39757,12 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
+"drR" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "drV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -40575,6 +39836,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"dsY" = (
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "dtt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -40614,16 +39888,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"dvb" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "dvq" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -40785,6 +40049,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"dxq" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "dyc" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -41178,16 +40446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"dDe" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "dDf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -41342,20 +40600,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"dFz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "dFY" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
@@ -41439,6 +40683,16 @@
 /obj/machinery/holopad/emergency,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"dHM" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_z = -28
+	},
+/obj/structure/table,
+/obj/item/camera,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "dIn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41547,6 +40801,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"dKr" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/machinery/grill,
+/obj/item/stack/sheet/mineral/coal/ten,
+/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "dKv" = (
 /obj/item/storage/box/disks{
 	pixel_x = 2;
@@ -41793,6 +41058,16 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/solars/starboard/fore)
+"dPb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dPt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42310,20 +41585,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"eam" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "eaJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42398,20 +41659,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ecJ" = (
-/obj/machinery/button/door{
-	id = "kitchenwindow";
-	name = "Window Shutter Control";
-	pixel_x = -6;
-	pixel_y = -24;
-	req_access_txt = "28"
-	},
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "ecK" = (
 /obj/structure/table,
 /obj/item/storage/box/evidence,
@@ -42547,31 +41794,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"efJ" = (
-/obj/machinery/processor,
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"egh" = (
-/obj/item/radio/intercom{
-	pixel_y = 21
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Club - Fore"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "egi" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small{
@@ -42747,6 +41969,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"ejM" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;46"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ejN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -42838,6 +42075,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
+"elt" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "elu" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -42889,6 +42132,16 @@
 	},
 /turf/open/space,
 /area/solar/port/fore)
+"elX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/bar)
 "emg" = (
 /obj/structure/filingcabinet/security{
 	pixel_x = 4
@@ -43140,6 +42393,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"esV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "esY" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -43560,6 +42831,21 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"eCB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "eDa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -43653,6 +42939,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"eFu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/machinery/camera{
+	c_tag = "Art Storage"
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "eFN" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 1;
@@ -43675,6 +42982,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"eFV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"eGj" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "eGB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -43731,6 +43048,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"eIL" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "eJn" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/neutral{
@@ -43955,24 +43280,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"eOb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "eOc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43992,6 +43299,15 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"ePj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ePm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/nosmoking{
@@ -44117,6 +43433,11 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"eSs" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "eSt" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -44510,6 +43831,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"fcE" = (
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "fcQ" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -44540,6 +43871,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"fdi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -44560,16 +43899,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"fdO" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "fdQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -44612,6 +43941,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"feJ" = (
+/obj/machinery/button/door{
+	id = "kitchenhydro";
+	name = "Service Shutter Control";
+	pixel_x = 7;
+	pixel_y = -24;
+	req_access_txt = "28"
+	},
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "feV" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
@@ -44811,6 +44153,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"fim" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fiv" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
@@ -45325,17 +44673,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"fwt" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "fwB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/security{
@@ -46345,6 +45682,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/head_of_personnel)
+"fUt" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "fUD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -46511,6 +45857,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"fXW" = (
+/obj/structure/table,
+/obj/item/airlock_painter,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "fYa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46607,6 +45959,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"gaM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood/poker,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/toy/cards/deck{
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gbb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -46949,6 +46310,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"gjz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gkK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -47006,6 +46376,17 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/port/aft)
+"glH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad/emergency/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "glN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -47139,6 +46520,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"gqe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/sign/departments/botany{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gqw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -47328,6 +46721,20 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom,
 /area/crew_quarters/kitchen/coldroom)
+"guI" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass{
+	amount = 30
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wrench,
+/obj/item/vending_refill/cigarette,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "guS" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -47379,14 +46786,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gwH" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gwT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47651,14 +47050,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"gDf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+"gCp" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -47862,18 +47264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"gGq" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "gGs" = (
 /obj/machinery/light{
 	dir = 8
@@ -48000,6 +47390,12 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"gIt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gIC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48456,6 +47852,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"gTT" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "gUb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -48534,28 +47937,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"gWv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"gWo" = (
+/obj/machinery/food_cart,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/machinery/door/airlock/grunge{
-	name = "Club"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "gWC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
@@ -48703,24 +48090,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"hav" = (
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "haE" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/stripes/line,
@@ -48803,6 +48172,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"hcD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "kitchenwindow";
+	name = "kitchen shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "hcS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49426,18 +48806,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"hrb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/grill,
-/obj/item/stack/sheet/mineral/coal/ten,
-/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "hrr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/storage/tech";
@@ -49599,14 +48967,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"huH" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "huJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49985,17 +49345,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"hBB" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/mint,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "hBE" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -50304,6 +49653,36 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
+"hHN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Hydroponics Desk";
+	req_one_access_txt = "30;35"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "hHS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -50769,18 +50148,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"hPH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "hPJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -51180,6 +50547,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hZa" = (
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "hZd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -51376,6 +50752,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ieY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "ifw" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51421,6 +50804,14 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"ifM" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/musician/piano,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "ifN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -51726,6 +51117,22 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"inq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "int" = (
 /obj/machinery/firealarm{
 	pixel_y = -26
@@ -51767,22 +51174,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/aft)
-"ioA" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 19
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ioE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security E.V.A. Storage";
@@ -51873,22 +51264,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"irK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
+"irf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"irz" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/item/storage/photo_album/bar,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = 5
 	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "irP" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -51993,6 +51386,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"ium" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iuv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52003,6 +51403,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"iuy" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "iuO" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -52020,19 +51432,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"iuQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "iuU" = (
 /obj/machinery/door/airlock/wood{
 	doorClose = 'sound/effects/doorcreaky.ogg';
@@ -52071,6 +51470,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"ivV" = (
+/obj/machinery/light/small,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe";
+	pixel_x = -4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iwh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -52242,6 +51650,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"izl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "izF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52328,6 +51753,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"iAC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iAD" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -52377,6 +51808,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"iCb" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iCo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -52675,6 +52115,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iKZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iLj" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -53081,31 +52535,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"iVy" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen Cold Room";
-	req_access_txt = "28"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "iVz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -53260,6 +52689,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"iYo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iYy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
@@ -53585,6 +53026,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jhd" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -29
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jhn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -53696,6 +53146,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"jkv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 19
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jkQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -53960,6 +53423,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jqU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 5
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "jri" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -54604,6 +54081,14 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jFB" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "kitchenwindow";
+	name = "kitchen shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "jGe" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
@@ -54828,21 +54313,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"jKh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/kitchen/coldroom";
-	dir = 1;
-	name = "Kitchen Cold Room APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "jLy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -55468,19 +54938,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"jZS" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jZX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55630,6 +55087,18 @@
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
+"kdG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kdR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56722,6 +56191,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"kzp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kzE" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -56805,6 +56283,18 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"kBX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kCe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56830,6 +56320,16 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"kDj" = (
+/obj/machinery/disposal/bin{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "kDo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -56874,6 +56374,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"kES" = (
+/obj/machinery/vending/classicbeats,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "kEX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56966,6 +56473,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kGr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kGY" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -57104,6 +56617,21 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"kKg" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/obj/item/kirbyplants{
+	desc = "A reminder of why we can't have nice things.";
+	name = "Potty the plant"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kKi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57607,6 +57135,18 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"kRk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "kRz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -57758,6 +57298,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"kWb" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "kWk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -57789,14 +57336,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kWu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "kWP" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -57888,6 +57427,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"kYS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "kYW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -57944,24 +57492,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lbS" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	desc = "A reminder of why we can't have nice things.";
-	name = "Potty the plant"
-	},
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "lcl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58002,23 +57532,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lcY" = (
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ldb" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
 /turf/closed/wall,
 /area/engine/atmos)
-"ldy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ldE" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -58054,20 +57579,23 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
-"lee" = (
+"leg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = -23
+/obj/machinery/camera{
+	c_tag = "Kitchen - Coldroom";
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+/obj/machinery/airalarm/kitchen_cold_room{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/food_cart,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
@@ -58098,6 +57626,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lfc" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/packageWrap{
+	pixel_x = 6
+	},
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "lft" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59003,6 +58552,24 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"ltm" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Art Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "ltn" = (
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard Access";
@@ -59324,6 +58891,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"lBS" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "lBT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -59513,6 +59087,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"lGq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lGA" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -59687,6 +59268,14 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
+"lKk" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lKm" = (
 /obj/machinery/light{
 	dir = 4
@@ -60085,13 +59674,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"lSe" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lSq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -60300,20 +59882,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"lWM" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Art Storage"
-	},
+"lXa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/storage/art)
+/area/hallway/primary/central)
 "lXp" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
@@ -60635,6 +60214,18 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"mhg" = (
+/obj/machinery/power/apc{
+	areastring = "/area/storage/art";
+	name = "Art Storage APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "mhk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60748,6 +60339,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"mlo" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"mlq" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "mlv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -61081,6 +60686,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"msx" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "msQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -61191,14 +60804,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"mvn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "mvr" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -61612,6 +61217,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mDo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "mDQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -61751,6 +61366,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"mHp" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "mHq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /mob/living/carbon/monkey,
@@ -61948,6 +61567,13 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"mMC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "mNc" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -62384,6 +62010,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mXC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "mXK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -62531,6 +62164,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"naR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_x = -4;
+	pixel_y = 28;
+	req_access_txt = "28"
+	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "naS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -62646,6 +62296,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"ndb" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nde" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -62730,6 +62387,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"nfv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "nfG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -63411,19 +63077,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"nro" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "nrG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -63487,6 +63140,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ntB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ntH" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/poddoor/preopen{
@@ -63856,14 +63518,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
-"nCG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "nCH" = (
 /obj/structure/sink{
 	dir = 4;
@@ -64018,24 +63672,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"nGB" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = 23
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "nGD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -64179,6 +63815,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"nIE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "nJI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64518,6 +64160,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"nQH" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nQJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -64653,6 +64301,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"nVd" = (
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "nVh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
@@ -64843,6 +64498,18 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nYP" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/camera{
+	c_tag = "Bar"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -65329,6 +64996,20 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"oiN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "ojg" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
@@ -65518,22 +65199,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"onI" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/reinforced,
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	dir = 1;
-	pixel_y = 32;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "onP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -65910,6 +65575,19 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"owq" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "owu" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -66448,35 +66126,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"oFS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
-"oFT" = (
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Kitchen Shutters Control";
-	pixel_x = -4;
-	pixel_y = 26;
-	req_access_txt = "28"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -23;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "oFZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -66492,31 +66141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"oGk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Hydroponics Desk";
-	req_one_access_txt = "30;35"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "oGn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/turretid{
@@ -66667,6 +66291,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"oJu" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oJQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -67415,18 +67055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"oXM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "oXP" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight/pen{
@@ -67604,6 +67232,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pcC" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/bar";
+	dir = 1;
+	name = "Bar APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pcL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67763,13 +67403,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pgg" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pgk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -68228,6 +67861,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pql" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "pqx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -68296,6 +67941,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"pro" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "prr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68706,6 +68363,16 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
+"pCc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "pCu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68941,6 +68608,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"pGA" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pGQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -69072,6 +68744,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pLh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/kitchenspike,
+/obj/machinery/camera{
+	c_tag = "Kitchen - Coldroom";
+	dir = 8
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "pLo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
@@ -69146,6 +68827,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pNx" = (
+/obj/machinery/vending/cola/random,
+/obj/machinery/camera{
+	c_tag = "Club - Aft";
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "pNU" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -69441,6 +69130,17 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"pTI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "pTN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -69630,22 +69330,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
-"pZl" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "pZm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -69705,6 +69389,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"qaO" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qaU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69879,6 +69571,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"qdw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "qee" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/security/glass{
@@ -69947,6 +69652,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qfJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qgb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -70152,6 +69866,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"qkd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"qkw" = (
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qky" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -70249,6 +69972,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"qmk" = (
+/obj/effect/landmark/start/cook,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "qmH" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -70486,14 +70215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"qqR" = (
-/obj/structure/table/wood/poker,
-/obj/item/clothing/head/fedora,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "qqW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70805,23 +70526,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"qxC" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/machinery/newscaster{
-	dir = 1;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "qxP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71825,6 +71529,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qWk" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -29
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "qWQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -71893,6 +71604,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"qXB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "qXC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -71949,6 +71666,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"qYt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "qYO" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;63;48;50"
@@ -72058,6 +71786,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"raI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rbq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -72097,6 +71834,10 @@
 /obj/effect/landmark/start/lieutenant,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rbP" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rck" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -72419,15 +72160,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/bridge)
-"rit" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/holopad/emergency/bar,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "riv" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -72678,29 +72410,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"rnC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Kitchen - Coldroom";
-	dir = 1
-	},
-/obj/machinery/airalarm/kitchen_cold_room{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "rnL" = (
 /obj/item/cigbutt,
 /obj/machinery/power/apc/highcap/five_k{
@@ -72925,6 +72634,13 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"rtY" = (
+/obj/machinery/camera{
+	c_tag = "Kitchen Hatch";
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ruc" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Courtroom"
@@ -73339,14 +73055,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"rCb" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "rCm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73567,12 +73275,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"rFZ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "rGh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74027,10 +73729,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"rOP" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "rPm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Dock Maintenance";
@@ -74286,18 +73984,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"rUb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "rUe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -74647,6 +74333,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"scS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "sdi" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -74837,6 +74529,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"shG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/cigarette/pipe,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "sil" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -74986,19 +74685,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"snk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = -26;
-	pixel_z = -28
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "snr" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -75100,6 +74786,12 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"sph" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "spH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -75330,6 +75022,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"stx" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "stF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75369,26 +75067,6 @@
 /obj/structure/girder/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
-"svx" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "svE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -75464,6 +75142,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"sxf" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"sxl" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "sxB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -76142,6 +75840,12 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
+"sNC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "sNL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -76279,16 +75983,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"sQe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/dark/visible,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "sQf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -76349,21 +76043,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"sSK" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;46"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "sSX" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/effect/turf_decal/tile/neutral{
@@ -76454,6 +76133,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sVt" = (
+/obj/structure/table,
+/obj/item/paper_bin/construction,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/item/hand_labeler,
+/obj/item/camera_film,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "sVz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -76658,6 +76351,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
+"tbr" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	dir = 1;
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tbR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -76682,6 +76387,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tdc" = (
+/turf/open/floor/plasteel,
+/area/storage/art)
 "tdE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -77857,31 +77565,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"tGJ" = (
-/obj/structure/table,
-/obj/machinery/power/apc{
-	areastring = "/area/storage/art";
-	dir = 8;
-	name = "Art Storage APC";
-	pixel_x = -24
-	},
-/obj/item/paper_bin,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "tHh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -78187,6 +77870,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"tOd" = (
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo";
+	pixel_x = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "tOe" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
@@ -78229,6 +77923,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tOQ" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "tPq" = (
 /obj/machinery/door/airlock/external{
 	req_one_access_txt = "13,8"
@@ -78242,6 +77940,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tQa" = (
+/obj/structure/table/wood,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/machinery/camera{
+	c_tag = "Bar - Backroom"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tQo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -78459,6 +78170,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"tTW" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "tTX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -78482,6 +78198,16 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"tUr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tUy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78550,25 +78276,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tWo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"tXC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
 	},
-/obj/item/radio/intercom{
-	pixel_y = -29
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "tXK" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"tXN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tXR" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -78620,6 +78350,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"tYY" = (
+/obj/machinery/camera{
+	c_tag = "Club - Fore"
+	},
+/obj/machinery/computer/arcade,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tZh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78680,6 +78417,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uat" = (
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "uaE" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -79128,6 +78871,20 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
+"una" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "uns" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -79216,12 +78973,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"uoI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "uoJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "CloningDoor";
@@ -79380,6 +79131,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"usT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "usV" = (
 /obj/machinery/light{
 	dir = 4
@@ -79717,6 +79477,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"uxE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uxI" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment,
@@ -80088,6 +79857,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"uEU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/window/southright{
+	dir = 4;
+	name = "Bar Door";
+	req_one_access_txt = "25;28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "uFh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -80491,15 +80272,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"uQC" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "uRs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80631,23 +80403,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"uUj" = (
-/obj/machinery/door/airlock{
-	name = "Bar Access";
-	req_access_txt = "25"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "uUm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -80927,16 +80682,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"vbY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vck" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -81141,26 +80886,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"viP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "viW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -81221,20 +80946,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vju" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/table/wood/poker,
-/obj/item/storage/pill_bottle/dice,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "vjB" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -81339,6 +81050,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vmM" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "vmP" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -81362,29 +81085,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"vnf" = (
-/obj/machinery/light{
-	dir = 4
+"vny" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/structure/rack,
-/obj/item/stack/packageWrap{
-	pixel_x = 6
-	},
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/cafeteria{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "vnJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -81731,15 +81441,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"vxi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vxk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -81798,6 +81499,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vacant_room/office)
+"vyh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "vyl" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -81902,16 +81609,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
-"vAw" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "vAE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -81993,6 +81690,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"vBX" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "vBY" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -82362,15 +82070,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"vLs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vLy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment{
@@ -82551,18 +82250,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vOf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "vOt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -82640,19 +82327,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vPM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/easel,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = 23
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "vQt" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow,
@@ -83106,6 +82780,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"waO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "waV" = (
 /obj/machinery/power/emitter/welded{
 	dir = 1
@@ -83481,6 +83165,13 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"wil" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "wiu" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
@@ -83574,6 +83265,18 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
+"wlu" = (
+/obj/machinery/button/door{
+	id = "kitchenwindow";
+	name = "Window Shutter Control";
+	pixel_x = -28;
+	req_access_txt = "28"
+	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "wlH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -83683,18 +83386,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"woI" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "woW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -84203,14 +83894,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wzm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "wzS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84440,15 +84123,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"wGH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wHc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84549,6 +84223,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"wJW" = (
+/obj/structure/sign/barsign{
+	pixel_y = 32
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wKo" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/closed/wall,
@@ -84713,6 +84396,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wNZ" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "wOn" = (
 /turf/open/floor/carpet/green,
 /area/maintenance/port/aft)
@@ -84749,6 +84437,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
+"wOP" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/bar)
 "wOY" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -85187,6 +84880,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"wXM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wXR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -85387,6 +85085,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xaW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/lootdrop/gambling,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xbl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -85582,13 +85288,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xew" = (
-/obj/effect/landmark/start/cook,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "xex" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/delivery,
@@ -85711,6 +85410,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xhG" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "xic" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -85917,6 +85625,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xni" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "xno" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -86224,20 +85941,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"xtz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "xtJ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -86315,6 +86018,19 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xvv" = (
+/obj/item/radio/intercom{
+	pixel_y = 21
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"xvJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xwl" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -86525,29 +86241,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/moonshine,
 /turf/open/floor/carpet/royalblue,
 /area/vacant_room/office)
-"xAQ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "xBe" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/keycard_auth{
@@ -86958,6 +86651,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xJY" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xKn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -87025,6 +86722,21 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
+"xNx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xNF" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -87121,6 +86833,12 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"xOy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xOG" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -120049,7 +119767,7 @@ hmg
 bkQ
 bmJ
 boJ
-bra
+bkQ
 hvr
 fCv
 abO
@@ -120059,8 +119777,8 @@ bBQ
 bDz
 gFj
 bGV
-ldy
 bSQ
+lXa
 bLH
 bNt
 bOO
@@ -120305,8 +120023,8 @@ mfE
 qoW
 lku
 wBR
-wBR
-vxi
+raI
+kBX
 skB
 xel
 wBR
@@ -120316,8 +120034,8 @@ oXj
 cYq
 lJn
 hqI
-vbY
 wBR
+xel
 nuP
 wBR
 wBR
@@ -120562,8 +120280,8 @@ bhC
 qXe
 bkS
 bmK
-boK
-brc
+qaO
+iKZ
 brc
 gcI
 byw
@@ -120573,15 +120291,15 @@ byw
 bDB
 xKP
 bGX
-wGH
-bIs
-bIs
-bNu
-bIs
-bIs
-vLs
+wXM
+uxE
+wXM
+xvJ
+wXM
+wXM
+wXM
 bSR
-bUc
+gqe
 fQx
 whC
 dMl
@@ -120820,25 +120538,25 @@ ohO
 gwa
 bmL
 boL
-bmO
-bmO
+ltm
+bmM
 bmP
 abf
 abf
 bmP
-bBS
-gGq
-eOb
-bGY
-rOP
-dik
-lSe
-bNv
-bOP
-gwH
-lSe
-jZS
-bUd
+wJW
+qkw
+qfJ
+gIt
+elt
+bKe
+bKe
+hcD
+jFB
+jFB
+bKe
+bSS
+oJu
 bVq
 bWJ
 eza
@@ -121075,28 +120793,28 @@ aZt
 bhE
 jCs
 bkU
-bmM
-aao
-tGJ
 bmO
-hav
-abP
-abS
-bAi
-bBT
-bwO
-iuQ
-bGZ
-bIt
+qdw
+aYZ
+mhg
+bmP
+irz
+vmM
+bmP
+bmP
+bBS
+esV
+eCB
+bBS
 bKe
-bLI
-svx
-pZl
-xAQ
-bLI
+gWo
+bLK
+wyV
+bLK
+wlu
 bST
 bUe
-oGk
+hHN
 xaO
 bST
 bUe
@@ -121330,27 +121048,27 @@ bco
 bdS
 bfH
 bhF
-vOf
-oXM
-lWM
-oFS
-snk
+jCs
+usT
 bmO
-aat
-aaL
-byy
-bAj
-bBT
-bDD
-dFz
-bHa
-lbS
+eFu
+tdc
+pCc
+bmP
+fUt
+bwO
+bwO
+dsY
+bFt
+nsK
+xOy
+jhd
 bKe
-oFT
+eSs
 qBD
 peH
 vAE
-ecJ
+drR
 bST
 bUf
 bVs
@@ -121590,24 +121308,24 @@ bhE
 jCs
 bkU
 bmM
-vPM
-brf
-bmO
-onI
+fXW
+sVt
+dHM
+bmP
+nYP
+xhG
 bwO
-bwO
-bAk
-rit
-bwO
-iuQ
-bGZ
-bBT
-chZ
+aID
+xJY
+oXD
+sNC
+xJY
+pql
 bLK
 bNx
-wyV
+kWb
 pVb
-bRR
+feJ
 bST
 bUg
 bVt
@@ -121845,24 +121563,24 @@ bdU
 bfJ
 bhG
 ehV
-bkW
+tUr
 bmO
 bmO
 bmO
 bmO
-aaF
-aaM
-byz
-bAj
-bBU
+bmP
+pTI
 bwO
-xtz
-bHb
-bMP
-irK
+bwO
+lKk
+xJY
+glH
+iAC
+pGA
+tXC
 bLL
-kWu
-bOT
+fdi
+owq
 bQC
 bLK
 hWK
@@ -122106,20 +121824,20 @@ bkU
 bmP
 boP
 brg
-bto
+guI
 bmP
-qxC
+kKg
 bwO
-bAl
-bBT
 bwO
-nro
-bHc
-bIw
-bKh
+vBX
+xJY
+gjz
+byC
+xJY
+izl
 bLM
-hBB
-bOS
+bNx
+wil
 hPW
 lxf
 bST
@@ -122359,26 +122077,26 @@ aZt
 aZt
 bhI
 oRT
-bkX
+waO
 bmP
-boQ
+tbr
 brh
 btp
 hIZ
 bwP
 byA
-bAm
-bBV
 bDF
-gDf
-bwO
-bBT
-viP
-bLN
-dDe
-bRQ
+nfv
+tXN
+nsK
+stx
+rtY
+bKe
+naR
+bNx
+sph
 tIn
-vAw
+dKr
 bST
 bUj
 bVu
@@ -122618,22 +122336,22 @@ bhE
 jCs
 bkU
 bmP
-boR
+tQa
 bri
-btq
+qkd
 bmP
-nGB
+gCp
 bwO
-bAn
-bBT
 bwO
-iuQ
-bwO
-woI
-eam
-wzm
-hrb
-bRS
+una
+xJY
+oXD
+wNZ
+cWI
+bKe
+oiN
+bED
+irf
 sBB
 bLL
 rBy
@@ -122875,22 +122593,22 @@ bhE
 jCs
 bkU
 bmP
-dbd
+ium
 brj
-btr
+ivV
 bmP
-bmP
-uUj
-bAo
-dhT
-aAs
-gWv
-dhT
-bmP
+jqU
+uEU
+eIL
+lKk
+byC
+oXD
+nQH
+byC
 bKe
 vbG
 tYa
-xew
+vyh
 xxI
 mhb
 pbu
@@ -123133,10 +122851,10 @@ jCs
 dCM
 bmP
 boT
-brk
+ntB
+ndb
 bmP
-bmP
-dqz
+xvv
 byC
 byC
 byC
@@ -123146,9 +122864,9 @@ uNv
 uNv
 quv
 tUl
-huH
-vnf
-efJ
+eGj
+qmk
+eGj
 iwq
 ozv
 bUh
@@ -123392,21 +123110,21 @@ bmP
 boU
 nVh
 bmP
-buP
-uoI
-bwX
-bwX
+bmP
+pcC
+stx
+stx
 byC
 byC
-rwq
-byC
-pgg
+pro
+stx
+lcY
 bKe
 bKe
-bKe
-bKe
-bKe
-iVy
+bDC
+lfc
+fcE
+iwq
 oub
 bUm
 pgY
@@ -123649,21 +123367,21 @@ alq
 boV
 brm
 bmP
-buQ
+kES
 byX
-qqR
-fdO
-uNv
-uQC
-vju
-rUb
-byC
-bKl
+qYt
+kzp
+lGq
+lGq
+xNx
+kdG
+mHp
+kDj
 rUK
-rCb
-bOX
-bQI
-tWo
+rUK
+rUK
+rUK
+cxN
 bST
 bUn
 lkf
@@ -123903,24 +123621,24 @@ xpT
 kDw
 wyS
 alq
-bBj
-brn
-bmP
-bmP
-egh
-byE
-bAq
+xni
+jkv
+ejM
+elX
+sxl
+mlo
+iCb
 dCU
 byC
-bwX
-oXD
+nQH
+iYo
 dCU
-bKm
+gTT
 rUK
-jKh
-cvB
-cUp
-rnC
+tOd
+bOX
+ieY
+leg
 bST
 bUo
 bVy
@@ -124160,24 +123878,24 @@ bhL
 cjO
 bla
 nOy
-boX
-ioA
-sSK
-mvn
-nCG
-byF
-bwX
+kYS
+kRk
+bmP
+mMC
+kGr
+brj
+sNC
 byC
 cTR
-bFt
-nsK
 byC
-bKn
+ePj
+fim
+tTW
 rUK
-bNF
-bOZ
-bQJ
-lee
+ara
+scS
+sxf
+inq
 bST
 bST
 bST
@@ -124420,21 +124138,21 @@ alq
 alq
 vmG
 bmP
-buS
-bwW
-byG
-byC
+tYY
+bwX
+hZa
+sNC
 bwX
 bDI
 bwX
 oXD
-byC
-bKo
+wOP
+pNx
 rUK
-fwt
-bPa
-rFZ
-sQe
+msx
+uat
+nIE
+bAp
 guc
 bUp
 rUK
@@ -124677,20 +124395,20 @@ alq
 boY
 qCi
 bmP
-buT
+rbP
 bwX
-byH
-bAr
-bBY
-bDJ
-bFu
+bNj
+dPb
+gaM
+shG
+xaW
 rwq
 byC
-bKp
+qWk
 rUK
-bNG
-bNG
-bZx
+mlq
+tOQ
+pLh
 sSs
 gUD
 bUq
@@ -124936,13 +124654,13 @@ lIa
 bmP
 bmP
 byN
-dhU
-bAs
-bBZ
-bBZ
-bFv
-hPH
-dii
+lBS
+eFV
+dxq
+dxq
+mXC
+mDo
+nVd
 byN
 rUK
 rUK
@@ -125193,13 +124911,13 @@ kBc
 btt
 avs
 byN
-dvb
+ifM
 bAt
 bCa
 bDK
 bFw
 pRL
-bIA
+vny
 byN
 byN
 dil
@@ -125450,13 +125168,13 @@ tzz
 btu
 buU
 byN
-dhV
+iuy
 bAu
 bCb
 byJ
 bFx
 eBW
-bIB
+qXB
 kOY
 kJw
 bNI

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -195,10 +195,6 @@
 "abe" = (
 /turf/closed/wall,
 /area/security/prison)
-"abf" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "abg" = (
 /obj/machinery/door/poddoor{
 	id = "SecJusticeChamber";
@@ -4353,6 +4349,27 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aqt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/machinery/camera{
+	c_tag = "Art Storage"
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "aqv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/wood,
@@ -4516,18 +4533,6 @@
 /obj/machinery/computer/shuttle/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ara" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/kitchen/coldroom";
-	dir = 1;
-	name = "Kitchen Cold Room APC";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "arh" = (
 /obj/item/reagent_containers/glass/bottle/toxin{
 	pixel_x = 4;
@@ -7334,6 +7339,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"aDR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "aDU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7539,6 +7553,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"aEQ" = (
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "aEZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8257,15 +8277,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"aID" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/item/clothing/head/that,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aIK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -12615,15 +12626,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aYZ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "aZq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18098,6 +18100,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"btY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/cigarette/pipe,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "btZ" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -19385,18 +19394,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"bAp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "bAt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -19719,10 +19716,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bBS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bBW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20121,14 +20114,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bDC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/bar,
@@ -20320,15 +20305,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"bED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "bFp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20516,6 +20492,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
+"bGo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "bGr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -20647,6 +20630,18 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bHb" = (
+/obj/machinery/button/door{
+	id = "kitchenwindow";
+	name = "Window Shutter Control";
+	pixel_x = -28;
+	req_access_txt = "28"
+	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "bHd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -21845,6 +21840,12 @@
 /obj/machinery/libraryscanner,
 /turf/open/floor/wood,
 /area/library)
+"bMO" = (
+/obj/item/radio/intercom{
+	pixel_y = 21
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bMR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -21979,15 +21980,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"bNj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bNl" = (
 /turf/closed/wall,
 /area/gateway)
@@ -22256,6 +22248,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"bOv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bOw" = (
 /turf/closed/wall,
 /area/teleporter)
@@ -22829,6 +22830,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"bRv" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "bRx" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase{
@@ -24111,6 +24120,28 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bXG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barwindow";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bXH" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -25400,6 +25431,15 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"ccU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood/poker,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/toy/cards/deck{
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ccY" = (
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -26316,6 +26356,17 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"cgJ" = (
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo";
+	pixel_x = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "cgU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -28042,6 +28093,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"cmJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/bar)
 "cmK" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -28904,6 +28965,12 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"cpu" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "cpH" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/stripes/line{
@@ -30088,6 +30155,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"cub" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "cue" = (
 /obj/machinery/power/solar{
 	id = "aftport";
@@ -31161,32 +31234,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cxN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Kitchen Cold Room";
-	req_access_txt = "28"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "cxP" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -37089,13 +37136,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"cWI" = (
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "cWK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37461,6 +37501,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"daT" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dbb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -37568,6 +37618,15 @@
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
+"dbz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dbA" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -39335,6 +39394,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"dmm" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "dmq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39620,6 +39685,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"doY" = (
+/obj/machinery/camera{
+	c_tag = "Club - Fore"
+	},
+/obj/machinery/computer/arcade,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dpk" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating,
@@ -39757,12 +39829,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
-"drR" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "drV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -39836,19 +39902,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"dsY" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "dtt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -40049,10 +40102,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"dxq" = (
-/obj/structure/curtain/cloth/fancy,
+"dxt" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -29
+	},
 /turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/area/crew_quarters/bar)
+"dxB" = (
+/obj/machinery/light/small,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe";
+	pixel_x = -4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dyc" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -40098,6 +40163,13 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"dza" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "dzc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -40613,6 +40685,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"dGu" = (
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "dGG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -40648,6 +40730,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"dGZ" = (
+/obj/structure/table,
+/obj/item/airlock_painter,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/plasteel,
+/area/storage/art)
+"dHf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "dHj" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -40676,6 +40774,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dHH" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/bar";
+	dir = 1;
+	name = "Bar APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dHL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -40683,16 +40793,6 @@
 /obj/machinery/holopad/emergency,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"dHM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_z = -28
-	},
-/obj/structure/table,
-/obj/item/camera,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "dIn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40801,17 +40901,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"dKr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/grill,
-/obj/item/stack/sheet/mineral/coal/ten,
-/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "dKv" = (
 /obj/item/storage/box/disks{
 	pixel_x = 2;
@@ -41058,16 +41147,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/solars/starboard/fore)
-"dPb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "dPt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41423,6 +41502,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"dWO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "dWR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41880,6 +41971,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"ehy" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ehN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41969,21 +42066,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ejM" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;46"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ejN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -42075,12 +42157,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
-"elt" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "elu" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -42132,16 +42208,6 @@
 	},
 /turf/open/space,
 /area/solar/port/fore)
-"elX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/crew_quarters/bar)
 "emg" = (
 /obj/structure/filingcabinet/security{
 	pixel_x = 4
@@ -42393,24 +42459,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"esV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"erY" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/area/maintenance/starboard)
 "esY" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42831,21 +42888,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"eCB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "eDa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42939,27 +42981,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"eFu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/machinery/camera{
-	c_tag = "Art Storage"
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "eFN" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 1;
@@ -42982,16 +43003,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"eFV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"eGj" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "eGB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -43048,13 +43059,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"eIL" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"eHT" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eJn" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -43262,6 +43275,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eNt" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "eNz" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -43280,6 +43305,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"eNK" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "eOc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43299,15 +43334,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"ePj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ePm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/nosmoking{
@@ -43433,11 +43459,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"eSs" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "eSt" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -43789,6 +43810,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"fbI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/machinery/grill,
+/obj/item/stack/sheet/mineral/coal/ten,
+/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
+"fbM" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fbS" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
@@ -43831,16 +43869,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"fcE" = (
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	dir = 4;
-	pixel_x = 32
-	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "fcQ" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -43871,14 +43899,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"fdi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -43941,19 +43961,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"feJ" = (
-/obj/machinery/button/door{
-	id = "kitchenhydro";
-	name = "Service Shutter Control";
-	pixel_x = 7;
-	pixel_y = -24;
-	req_access_txt = "28"
+"feP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/crew_quarters/kitchen)
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "feV" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
@@ -44083,6 +44102,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"fgK" = (
+/obj/machinery/food_cart,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "fgX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -44153,12 +44178,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"fim" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "fiv" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
@@ -44370,6 +44389,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"fnP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "foh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45087,6 +45115,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"fEr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fEu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45177,6 +45216,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fGT" = (
+/obj/machinery/power/apc{
+	areastring = "/area/storage/art";
+	name = "Art Storage APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "fHu" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -45612,6 +45663,19 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
+"fRJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "fRM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -45682,15 +45746,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/head_of_personnel)
-"fUt" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "fUD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -45857,12 +45912,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"fXW" = (
-/obj/structure/table,
-/obj/item/airlock_painter,
-/obj/item/rcl/pre_loaded,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "fYa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45959,15 +46008,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"gaM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/wood/poker,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "gbb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -46224,6 +46264,18 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"gha" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ghz" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -46257,6 +46309,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"ghM" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -29
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ghY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46310,15 +46371,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"gjz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "gkK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -46376,17 +46428,6 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/port/aft)
-"glH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad/emergency/bar,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "glN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -46520,18 +46561,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"gqe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/sign/departments/botany{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gqw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -46721,20 +46750,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom,
 /area/crew_quarters/kitchen/coldroom)
-"guI" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass{
-	amount = 30
-	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wrench,
-/obj/item/vending_refill/cigarette,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "guS" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -46852,6 +46867,13 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"gyo" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gyp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -47050,20 +47072,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"gCp" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "gDg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light/small{
@@ -47390,12 +47398,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"gIt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gIC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -47409,6 +47411,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"gIM" = (
+/obj/structure/table/wood,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/machinery/camera{
+	c_tag = "Bar - Backroom"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gIO" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -47479,6 +47494,14 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"gJF" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "gJG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -47740,6 +47763,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gPQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "gPT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -47757,6 +47792,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gRy" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gRQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47852,13 +47894,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"gTT" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "gUb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -47937,12 +47972,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"gWo" = (
-/obj/machinery/food_cart,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "gWC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
@@ -48021,6 +48050,15 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
+"gZv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gZx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
@@ -48172,17 +48210,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"hcD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
 "hcS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48229,6 +48256,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"hdL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "hdX" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -48575,6 +48618,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hmt" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/item/clothing/head/that,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hmX" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -49371,6 +49423,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hCj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 19
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hCC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -49653,36 +49718,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
-"hHN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Hydroponics Desk";
-	req_one_access_txt = "30;35"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "hHS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -50115,6 +50150,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"hOY" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "hPf" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -50500,6 +50539,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hXM" = (
+/obj/structure/table,
+/obj/item/paper_bin/construction,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/item/hand_labeler,
+/obj/item/camera_film,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "hXU" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -50547,15 +50600,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hZa" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "hZd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -50583,6 +50627,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"hZo" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/photo_album/bar,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"hZT" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_z = -28
+	},
+/obj/structure/table,
+/obj/item/camera,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "iau" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50752,13 +50818,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ieY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "ifw" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50804,14 +50863,6 @@
 	dir = 1
 	},
 /area/engine/atmos)
-"ifM" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/structure/musician/piano,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "ifN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -51117,22 +51168,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"inq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "int" = (
 /obj/machinery/firealarm{
 	pixel_y = -26
@@ -51264,23 +51299,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"irf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"irz" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"irm" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/newscaster{
+	pixel_y = -30
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/photo_album/bar,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "irP" = (
 /obj/machinery/holopad,
@@ -51386,12 +51410,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"ium" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+"iuo" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 5
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "iuv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51403,18 +51434,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"iuy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "iuO" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -51470,15 +51489,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"ivV" = (
-/obj/machinery/light/small,
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe";
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iwh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -51628,6 +51638,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"iyr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iyV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -51650,23 +51666,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"izl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
 "izF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51724,6 +51723,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"izV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iAj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -51753,12 +51761,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"iAC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iAD" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -51808,15 +51810,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"iCb" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iCo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -51856,6 +51849,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"iDV" = (
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iEf" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "1;4;38;12"
@@ -52007,6 +52003,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"iId" = (
+/obj/machinery/button/door{
+	id = "kitchenhydro";
+	name = "Service Shutter Control";
+	pixel_x = 7;
+	pixel_y = -24;
+	req_access_txt = "28"
+	},
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "iIG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -52017,6 +52026,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iIL" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/camera{
+	c_tag = "Bar"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "iIV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52115,20 +52136,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"iKZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iLj" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -52489,6 +52496,17 @@
 /obj/item/stamp/hos,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"iTJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "kitchenwindow";
+	name = "kitchen shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "iUj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52689,16 +52707,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iYo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+"iYu" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "iYy" = (
@@ -53026,15 +53039,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"jhd" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -29
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "jhn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -53146,19 +53150,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"jkv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 19
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "jkQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -53423,20 +53414,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jqU" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag{
-	pixel_y = 5
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "jri" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -53491,6 +53468,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jtm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/kitchenspike,
+/obj/machinery/camera{
+	c_tag = "Kitchen - Coldroom";
+	dir = 8
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "jtr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Xenolab";
@@ -53585,6 +53571,32 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"juI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_x = -4;
+	pixel_y = 28;
+	req_access_txt = "28"
+	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
+"juM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jvj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -53820,6 +53832,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"jzH" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/bar)
 "jzQ" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/tile/neutral{
@@ -53885,6 +53902,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"jBl" = (
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jBu" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -53937,6 +53961,12 @@
 	dir = 1
 	},
 /area/chapel/main)
+"jCl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jCs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54062,6 +54092,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/library)
+"jFa" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jFi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
@@ -54081,14 +54120,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"jFB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
 "jGe" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
@@ -54219,6 +54250,20 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
+"jIj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "jIv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -54415,6 +54460,15 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jOf" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54951,6 +55005,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"kaP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kaT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -55087,18 +55147,6 @@
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
-"kdG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/table/wood,
-/obj/item/kitchen/fork,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kdR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55357,6 +55405,14 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/science/research)
+"kic" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/lootdrop/gambling,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kih" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -55937,6 +55993,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"ktJ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/button/door{
+	id = "barwindow";
+	name = "Bar Shutter Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kub" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56102,6 +56174,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"kyg" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kyn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -56191,15 +56267,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"kzp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/table/wood,
-/obj/item/kitchen/fork,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kzE" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -56215,6 +56282,20 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
+"kAY" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kBc" = (
 /obj/item/assembly/prox_sensor,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -56283,18 +56364,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kBX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kCe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56320,16 +56389,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"kDj" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "kDo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -56374,13 +56433,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"kES" = (
-/obj/machinery/vending/classicbeats,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "kEX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56461,6 +56513,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kGi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kGp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56473,12 +56532,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kGr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kGY" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -56617,21 +56670,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"kKg" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	dir = 1;
-	pixel_y = 30
-	},
-/obj/item/kirbyplants{
-	desc = "A reminder of why we can't have nice things.";
-	name = "Potty the plant"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "kKi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -56677,6 +56715,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"kLj" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kLz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -56935,6 +56987,16 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"kOT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/turf/open/floor/plasteel,
+/area/storage/art)
 "kOX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/head_of_personnel";
@@ -57135,18 +57197,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"kRk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "kRz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -57298,13 +57348,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"kWb" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "kWk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -57427,15 +57470,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"kYS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "kYW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -57532,12 +57566,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lcY" = (
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ldb" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
@@ -57579,26 +57607,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
-"leg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Kitchen - Coldroom";
-	dir = 1
-	},
-/obj/machinery/airalarm/kitchen_cold_room{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "ley" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -57626,27 +57634,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lfc" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/stack/packageWrap{
-	pixel_x = 6
-	},
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "lft" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57945,6 +57932,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lkC" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lkO" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Sanitarium";
@@ -58552,24 +58545,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"ltm" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Art Storage"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "ltn" = (
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard Access";
@@ -58693,6 +58668,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"lvi" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lvn" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -58851,6 +58842,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
+"lzl" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Art Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "lzo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58891,13 +58900,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"lBS" = (
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "lBT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -59029,6 +59031,12 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"lEt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "lEw" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -59087,13 +59095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"lGq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "lGA" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -59268,14 +59269,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
-"lKk" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "lKm" = (
 /obj/machinery/light{
 	dir = 4
@@ -59290,6 +59283,15 @@
 	dir = 8
 	},
 /area/medical/medbay/aft)
+"lKs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lKu" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -59604,6 +59606,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"lQz" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "lQN" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -59882,17 +59889,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"lXa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lXp" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
@@ -60214,18 +60210,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"mhg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/storage/art";
-	name = "Art Storage APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "mhk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60329,6 +60313,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mkO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mld" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -60339,20 +60328,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"mlo" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"mlq" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "mlv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -60686,14 +60661,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"msx" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "msQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -60859,6 +60826,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mvE" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "mvN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -61217,16 +61188,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mDo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "mDQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -61315,6 +61276,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mFH" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/kitchen/coldroom";
+	dir = 1;
+	name = "Kitchen Cold Room APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "mFN" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 2";
@@ -61366,10 +61339,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"mHp" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "mHq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /mob/living/carbon/monkey,
@@ -61567,13 +61536,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"mMC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/jukebox,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "mNc" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -62010,13 +61972,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"mXC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "mXK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -62164,23 +62119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"naR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Kitchen Shutters Control";
-	pixel_x = -4;
-	pixel_y = 28;
-	req_access_txt = "28"
-	},
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "naS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -62296,13 +62234,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"ndb" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "nde" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -62387,15 +62318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"nfv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "nfG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -62447,6 +62369,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ngJ" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ngM" = (
 /obj/item/book/manual/wiki/security_space_law{
 	name = "space law";
@@ -62751,6 +62677,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"nkP" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "nlf" = (
 /obj/machinery/door/window{
 	name = "HoP's Desk";
@@ -63110,6 +63046,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"nsr" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nsK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -63140,15 +63081,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ntB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ntH" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/poddoor/preopen{
@@ -63351,6 +63283,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nyn" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "nyG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -63371,6 +63306,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"nyS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nyV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -63815,12 +63759,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"nIE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "nJI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63989,6 +63927,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"nNs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Kitchen Cold Room";
+	req_access_txt = "28"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "nNE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -64160,12 +64124,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"nQH" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "nQJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -64301,13 +64259,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"nVd" = (
-/obj/structure/sign/poster/random{
-	pixel_y = -32
-	},
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "nVh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
@@ -64462,6 +64413,17 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/engine/cult,
 /area/library)
+"nXD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nXL" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far";
@@ -64473,6 +64435,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nXN" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "nYi" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -64498,18 +64468,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"nYP" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/camera{
-	c_tag = "Bar"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -64587,6 +64545,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/library)
+"oaY" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;46"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "obb" = (
 /obj/structure/target_stake,
 /turf/open/floor/plasteel/white,
@@ -64996,20 +64969,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"oiN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "ojg" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
@@ -65240,6 +65199,15 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"opF" = (
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "opW" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -65575,19 +65543,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
-"owq" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "owu" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -66291,22 +66246,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"oJu" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oJQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -66400,6 +66339,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oMg" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass{
+	amount = 30
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wrench,
+/obj/item/vending_refill/cigarette,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "oMh" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -66861,6 +66814,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"oVz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "oVC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -67232,18 +67191,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pcC" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/bar";
-	dir = 1;
-	name = "Bar APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pcL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67266,6 +67213,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
+"pds" = (
+/obj/machinery/vending/classicbeats,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "pdw" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -67494,6 +67448,17 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"phQ" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "pik" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -67737,6 +67702,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"poi" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pom" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -67861,18 +67834,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"pql" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
 "pqx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -67941,18 +67902,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"pro" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "prr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68363,16 +68312,6 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
-"pCc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "pCu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68608,11 +68547,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"pGA" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pGQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -68704,6 +68638,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"pIG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"pIV" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "pJu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -68744,15 +68696,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"pLh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/kitchenspike,
-/obj/machinery/camera{
-	c_tag = "Kitchen - Coldroom";
-	dir = 8
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "pLo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
@@ -68827,14 +68770,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"pNx" = (
-/obj/machinery/vending/cola/random,
-/obj/machinery/camera{
-	c_tag = "Club - Aft";
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "pNU" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -69130,17 +69065,6 @@
 	dir = 1
 	},
 /area/engine/atmos)
-"pTI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "pTN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -69318,6 +69242,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"pYv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "pYw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -69389,14 +69330,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"qaO" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"qaG" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	dir = 1;
+	pixel_y = 32;
+	receive_ore_updates = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "qaU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69571,19 +69516,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"qdw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/structure/easel,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/turf/open/floor/plasteel,
-/area/storage/art)
 "qee" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/security/glass{
@@ -69652,15 +69584,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qfJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qgb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -69866,15 +69789,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"qkd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"qkw" = (
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qky" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -69972,12 +69886,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"qmk" = (
-/obj/effect/landmark/start/cook,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "qmH" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -71264,6 +71172,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qOz" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/packageWrap{
+	pixel_x = 6
+	},
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "qOA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -71304,6 +71233,14 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
+"qQm" = (
+/obj/machinery/vending/cola/random,
+/obj/machinery/camera{
+	c_tag = "Club - Aft";
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "qQt" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -71529,13 +71466,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qWk" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -29
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "qWQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -71604,12 +71534,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"qXB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "qXC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -71666,17 +71590,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"qYt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/table/wood,
-/obj/item/kitchen/fork,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "qYO" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;63;48;50"
@@ -71786,15 +71699,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"raI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "rbq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -71834,10 +71738,6 @@
 /obj/effect/landmark/start/lieutenant,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rbP" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "rck" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -72299,6 +72199,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"rkl" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "kitchenwindow";
+	name = "kitchen shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "rkn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -72634,13 +72542,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"rtY" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen Hatch";
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ruc" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Courtroom"
@@ -73027,6 +72928,12 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
+"rBT" = (
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rBU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73402,6 +73309,27 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"rHT" = (
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"rIj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barwindow";
+	name = "bar shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "rIl" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -73688,6 +73616,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rOj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rOk" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber";
@@ -73743,6 +73681,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"rPs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rPG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -73785,6 +73729,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rQR" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "rQZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73996,6 +73944,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"rUn" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "rUC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -74161,6 +74118,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"rXO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rXS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74234,6 +74198,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"sao" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
 "saq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -74333,12 +74304,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
-"scS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "sdi" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -74529,13 +74494,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"shG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/wood/poker,
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/item/clothing/mask/cigarette/cigar,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sil" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -74718,6 +74676,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"snS" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "sod" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -74786,12 +74751,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"sph" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/mint,
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "spH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -74925,6 +74884,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"sqV" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "srp" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/supply";
@@ -75022,12 +74987,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"stx" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "stF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75142,26 +75101,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"sxf" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
-"sxl" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sxB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -75840,12 +75779,6 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
-"sNC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sNL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -76043,6 +75976,14 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"sSO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "sSX" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/effect/turf_decal/tile/neutral{
@@ -76076,6 +76017,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sTW" = (
+/obj/machinery/disposal/bin{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "sUq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -76133,20 +76084,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sVt" = (
-/obj/structure/table,
-/obj/item/paper_bin/construction,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/hand_labeler,
-/obj/item/camera_film,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "sVz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -76352,15 +76289,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "tbr" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	dir = 1;
-	pixel_y = 32;
-	receive_ore_updates = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tbR" = (
@@ -76387,9 +76324,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"tdc" = (
-/turf/open/floor/plasteel,
-/area/storage/art)
 "tdE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -76531,6 +76465,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"thd" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/obj/item/kirbyplants{
+	desc = "A reminder of why we can't have nice things.";
+	name = "Potty the plant"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "thH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -76642,6 +76591,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tkR" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/window/southright{
+	dir = 4;
+	name = "Bar Door";
+	req_one_access_txt = "25;28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "tkV" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small{
@@ -77870,17 +77831,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"tOd" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -4
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "tOe" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
@@ -77923,10 +77873,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"tOQ" = (
-/obj/machinery/gibber,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "tPq" = (
 /obj/machinery/door/airlock/external{
 	req_one_access_txt = "13,8"
@@ -77940,19 +77886,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tQa" = (
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/machinery/camera{
-	c_tag = "Bar - Backroom"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "tQo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -78170,11 +78103,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"tTW" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/light,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "tTX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -78198,16 +78126,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"tUr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tUy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78236,6 +78154,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tVc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Kitchen - Coldroom";
+	dir = 1
+	},
+/obj/machinery/airalarm/kitchen_cold_room{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "tVt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78276,29 +78214,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tXC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
 "tXK" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"tXN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "tXR" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -78350,13 +78269,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"tYY" = (
-/obj/machinery/camera{
-	c_tag = "Club - Fore"
-	},
-/obj/machinery/computer/arcade,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "tZh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78417,12 +78329,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"uat" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/crew_quarters/kitchen/coldroom)
 "uaE" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -78630,6 +78536,11 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"ugn" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "ugJ" = (
 /obj/machinery/door/airlock/solgov{
 	name = "Storeroom";
@@ -78871,20 +78782,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
-"una" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "uns" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -78902,6 +78799,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"unv" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "unA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -79131,15 +79041,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"usT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "usV" = (
 /obj/machinery/light{
 	dir = 4
@@ -79430,6 +79331,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"uwQ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "uxk" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -79477,15 +79386,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"uxE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uxI" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment,
@@ -79857,18 +79757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"uEU" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/window/southright{
-	dir = 4;
-	name = "Bar Door";
-	req_one_access_txt = "25;28"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "uFh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -79924,6 +79812,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"uGo" = (
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "uGB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80288,6 +80183,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uRV" = (
+/obj/effect/landmark/start/cook,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "uRZ" = (
 /obj/item/radio/intercom{
 	pixel_x = -30
@@ -80440,6 +80341,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"uVc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uVC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -80487,6 +80402,18 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"uWZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/sign/departments/botany{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uXc" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -80623,6 +80550,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vaB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"vaP" = (
+/obj/machinery/camera{
+	c_tag = "Kitchen Hatch";
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vbl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
@@ -80699,6 +80648,12 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"vdt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "vdv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
@@ -80808,6 +80763,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vfZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/kitchen)
 "vgc" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "hosspace";
@@ -80958,6 +80926,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"vke" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "vkl" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -80968,6 +80948,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"vkJ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "vkY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -81050,18 +81039,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vmM" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/flask,
-/obj/item/reagent_containers/food/drinks/flask,
-/obj/item/reagent_containers/food/drinks/flask,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "vmP" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -81085,16 +81062,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"vny" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "vnJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -81499,12 +81466,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vacant_room/office)
-"vyh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "vyl" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -81690,17 +81651,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"vBX" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "vBY" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -81816,6 +81766,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"vFB" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/musician/piano,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "vFU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -81987,6 +81945,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vII" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vIO" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -82070,6 +82034,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"vLu" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vLy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment{
@@ -82092,6 +82066,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vLN" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "vLT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
@@ -82780,16 +82761,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"waO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "waV" = (
 /obj/machinery/power/emitter/welded{
 	dir = 1
@@ -83165,13 +83136,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"wil" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "wiu" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
@@ -83265,18 +83229,6 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
-"wlu" = (
-/obj/machinery/button/door{
-	id = "kitchenwindow";
-	name = "Window Shutter Control";
-	pixel_x = -28;
-	req_access_txt = "28"
-	},
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "wlH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -83479,6 +83431,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"wqa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wqb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -83543,6 +83501,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"wqQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wqT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -83566,6 +83533,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wrq" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "wrx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -83916,6 +83888,36 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wAL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Hydroponics Desk";
+	req_one_access_txt = "30;35"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wAW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -83923,6 +83925,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"wBe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad/emergency/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "wBj" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
@@ -83942,6 +83955,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"wBL" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barwindow";
+	name = "bar shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "wBR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84005,6 +84026,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"wEk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "wEL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -84223,15 +84255,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"wJW" = (
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wKo" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/closed/wall,
@@ -84318,6 +84341,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wMm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "wMt" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/gavelblock,
@@ -84355,6 +84390,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"wMJ" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "wNm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -84396,11 +84435,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wNZ" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/fork,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "wOn" = (
 /turf/open/floor/carpet/green,
 /area/maintenance/port/aft)
@@ -84437,11 +84471,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"wOP" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/crew_quarters/bar)
 "wOY" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -84684,6 +84713,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"wTk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "wTR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84880,11 +84919,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"wXM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wXR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -85085,14 +85119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"xaW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/lootdrop/gambling,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xbl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -85410,15 +85436,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"xhG" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/mob/living/carbon/monkey/punpun,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "xic" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -85625,15 +85642,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"xni" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "xno" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -86018,19 +86026,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"xvv" = (
-/obj/item/radio/intercom{
-	pixel_y = 21
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"xvJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xwl" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -86169,6 +86164,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"xyO" = (
+/obj/structure/sign/barsign{
+	pixel_y = 32
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xzr" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin3";
@@ -86651,10 +86655,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"xJY" = (
-/obj/structure/chair/stool/bar,
+"xKc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"xKg" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "xKn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -86678,6 +86694,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xKy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "xKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -86722,21 +86744,6 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
-"xNx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/table/wood,
-/obj/item/kitchen/fork,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xNF" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -86833,12 +86840,6 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"xOy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xOG" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -86868,6 +86869,9 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
+"xON" = (
+/turf/open/floor/plasteel,
+/area/storage/art)
 "xPa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -87594,6 +87598,25 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"yfP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barwindow";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "yfS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
@@ -119778,7 +119801,7 @@ bDz
 gFj
 bGV
 bSQ
-lXa
+fEr
 bLH
 bNt
 bOO
@@ -120023,8 +120046,8 @@ mfE
 qoW
 lku
 wBR
-raI
-kBX
+wqQ
+gha
 skB
 xel
 wBR
@@ -120280,8 +120303,8 @@ bhC
 qXe
 bkS
 bmK
-qaO
-iKZ
+poi
+uVc
 brc
 gcI
 byw
@@ -120291,15 +120314,15 @@ byw
 bDB
 xKP
 bGX
-wXM
-uxE
-wXM
-xvJ
-wXM
-wXM
-wXM
+mkO
+dbz
+mkO
+kGi
+mkO
+mkO
+mkO
 bSR
-gqe
+uWZ
 fQx
 whC
 dMl
@@ -120538,25 +120561,25 @@ ohO
 gwa
 bmL
 boL
-ltm
+lzl
 bmM
 bmP
-abf
-abf
+wBL
+wBL
 bmP
-wJW
-qkw
-qfJ
-gIt
-elt
+xyO
+iDV
+juM
+wqa
+ehy
 bKe
 bKe
-hcD
-jFB
-jFB
+iTJ
+rkl
+rkl
 bKe
 bSS
-oJu
+lvi
 bVq
 bWJ
 eza
@@ -120794,27 +120817,27 @@ bhE
 jCs
 bkU
 bmO
-qdw
-aYZ
-mhg
+fRJ
+vkJ
+fGT
 bmP
-irz
-vmM
+hZo
+eNt
 bmP
 bmP
-bBS
-esV
-eCB
-bBS
+rIj
+bXG
+yfP
+rIj
 bKe
-gWo
+fgK
 bLK
 wyV
 bLK
-wlu
+bHb
 bST
 bUe
-hHN
+wAL
 xaO
 bST
 bUe
@@ -121049,26 +121072,26 @@ bdS
 bfH
 bhF
 jCs
-usT
+jFa
 bmO
-eFu
-tdc
-pCc
+aqt
+xON
+kOT
 bmP
-fUt
+ktJ
 bwO
 bwO
-dsY
+rHT
 bFt
 nsK
-xOy
-jhd
+fbM
+ghM
 bKe
-eSs
+ugn
 qBD
 peH
 vAE
-drR
+dmm
 bST
 bUf
 bVs
@@ -121308,24 +121331,24 @@ bhE
 jCs
 bkU
 bmM
-fXW
-sVt
-dHM
+dGZ
+hXM
+hZT
 bmP
-nYP
-xhG
+iIL
+rUn
 bwO
-aID
-xJY
+hmt
+mvE
 oXD
-sNC
-xJY
-pql
+kaP
+mvE
+pIV
 bLK
 bNx
-kWb
+snS
 pVb
-feJ
+iId
 bST
 bUg
 bVt
@@ -121563,24 +121586,24 @@ bdU
 bfJ
 bhG
 ehV
-tUr
+daT
 bmO
 bmO
 bmO
 bmO
 bmP
-pTI
+wEk
 bwO
 bwO
-lKk
-xJY
-glH
-iAC
-pGA
-tXC
+bRv
+mvE
+wBe
+vII
+nsr
+vfZ
 bLL
-fdi
-owq
+sSO
+unv
 bQC
 bLK
 hWK
@@ -121824,20 +121847,20 @@ bkU
 bmP
 boP
 brg
-guI
+oMg
 bmP
-kKg
+thd
 bwO
 bwO
-vBX
-xJY
-gjz
+phQ
+mvE
+izV
 byC
-xJY
-izl
+mvE
+pYv
 bLM
 bNx
-wil
+xKg
 hPW
 lxf
 bST
@@ -122077,26 +122100,26 @@ aZt
 aZt
 bhI
 oRT
-waO
+wTk
 bmP
-tbr
+qaG
 brh
 btp
 hIZ
 bwP
 byA
 bDF
-nfv
-tXN
+aDR
+jCl
 nsK
-stx
-rtY
+sqV
+vaP
 bKe
-naR
+juI
 bNx
-sph
+cpu
 tIn
-dKr
+fbI
 bST
 bUj
 bVu
@@ -122336,22 +122359,22 @@ bhE
 jCs
 bkU
 bmP
-tQa
+gIM
 bri
-qkd
+rPs
 bmP
-gCp
+kLj
 bwO
 bwO
-una
-xJY
+kAY
+mvE
 oXD
-wNZ
-cWI
+wrq
+jBl
 bKe
-oiN
-bED
-irf
+jIj
+fnP
+lEt
 sBB
 bLL
 rBy
@@ -122593,22 +122616,22 @@ bhE
 jCs
 bkU
 bmP
-ium
+gyo
 brj
-ivV
+dxB
 bmP
-jqU
-uEU
-eIL
-lKk
+iuo
+tkR
+uwQ
+bRv
 byC
 oXD
-nQH
+lkC
 byC
 bKe
 vbG
 tYa
-vyh
+vdt
 xxI
 mhb
 pbu
@@ -122851,10 +122874,10 @@ jCs
 dCM
 bmP
 boT
-ntB
-ndb
+bOv
+gRy
 bmP
-xvv
+bMO
 byC
 byC
 byC
@@ -122864,9 +122887,9 @@ uNv
 uNv
 quv
 tUl
-eGj
-qmk
-eGj
+nyn
+uRV
+nyn
 iwq
 ozv
 bUh
@@ -123111,19 +123134,19 @@ boU
 nVh
 bmP
 bmP
-pcC
-stx
-stx
+dHH
+sqV
+sqV
 byC
 byC
-pro
-stx
-lcY
+wMm
+sqV
+rBT
 bKe
 bKe
-bDC
-lfc
-fcE
+gJF
+qOz
+dGu
 iwq
 oub
 bUm
@@ -123367,21 +123390,21 @@ alq
 boV
 brm
 bmP
-kES
+pds
 byX
-qYt
-kzp
-lGq
-lGq
-xNx
-kdG
-mHp
-kDj
+nXD
+nyS
+iYu
+iYu
+vaB
+tbr
+kyg
+sTW
 rUK
 rUK
 rUK
 rUK
-cxN
+nNs
 bST
 bUn
 lkf
@@ -123621,24 +123644,24 @@ xpT
 kDw
 wyS
 alq
-xni
-jkv
-ejM
-elX
-sxl
-mlo
-iCb
+erY
+hCj
+oaY
+cmJ
+vLu
+eHT
+jOf
 dCU
 byC
-nQH
-iYo
+lkC
+feP
 dCU
-gTT
+irm
 rUK
-tOd
+cgJ
 bOX
-ieY
-leg
+dza
+tVc
 bST
 bUo
 bVy
@@ -123878,24 +123901,24 @@ bhL
 cjO
 bla
 nOy
-kYS
-kRk
+lKs
+vke
 bmP
-mMC
-kGr
+rXO
+oVz
 brj
-sNC
+kaP
 byC
 cTR
 byC
-ePj
-fim
-tTW
+gZv
+iyr
+lQz
 rUK
-ara
-scS
-sxf
-inq
+mFH
+cub
+nkP
+hdL
 bST
 bST
 bST
@@ -124138,21 +124161,21 @@ alq
 alq
 vmG
 bmP
-tYY
+doY
 bwX
-hZa
-sNC
+opF
+kaP
 bwX
 bDI
 bwX
 oXD
-wOP
-pNx
+jzH
+qQm
 rUK
-msx
-uat
-nIE
-bAp
+nXN
+aEQ
+pIG
+dWO
 guc
 bUp
 rUK
@@ -124395,20 +124418,20 @@ alq
 boY
 qCi
 bmP
-rbP
+ngJ
 bwX
-bNj
-dPb
-gaM
-shG
-xaW
+xKc
+rOj
+ccU
+btY
+kic
 rwq
 byC
-qWk
+dxt
 rUK
-mlq
-tOQ
-pLh
+rQR
+wMJ
+jtm
 sSs
 gUD
 bUq
@@ -124654,13 +124677,13 @@ lIa
 bmP
 bmP
 byN
-lBS
-eFV
-dxq
-dxq
-mXC
-mDo
-nVd
+vLN
+sao
+hOY
+hOY
+bGo
+dHf
+uGo
 byN
 rUK
 rUK
@@ -124911,13 +124934,13 @@ kBc
 btt
 avs
 byN
-ifM
+vFB
 bAt
 bCa
 bDK
 bFw
 pRL
-vny
+eNK
 byN
 byN
 dil
@@ -125168,13 +125191,13 @@ tzz
 btu
 buU
 byN
-iuy
+gPQ
 bAu
 bCb
 byJ
 bFx
 eBW
-qXB
+xKy
 kOY
 kJw
 bNI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes up the Bar and Kitchen design on Meta to reflect the design used from VG. 

![image](https://user-images.githubusercontent.com/6519623/105731449-6b9b2a80-5efd-11eb-9fac-af1aa9dc2c40.png)

![image](https://user-images.githubusercontent.com/6519623/105731532-8077be00-5efd-11eb-9d65-b8eab65b8eb5.png)

## Why It's Good For The Game

Whole area of the bar is visible, instead of half of it being visible from the Bartender / Chef. A smaller serving hatch, and lack of one from the main hall, incentivizes coming into the bar and sitting down at a table. Kitchen space was expanded a little bit, as well as shrinking the cold room just a tad. Also, I think it looks nice.

## Changelog
:cl:
tweak: Metastation Bar and Kitchen redesigned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
