### PR TITLE
adds showers and stasis

### DIFF
--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -560,13 +560,11 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bT" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/vending/classicbeats,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bU" = (
@@ -637,7 +635,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "jm" = (
@@ -657,6 +655,12 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"tU" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Cg" = (
 /obj/machinery/door/airlock/titanium{
@@ -860,7 +864,7 @@ bd
 aN
 aE
 bn
-bi
+tU
 bw
 bz
 bC

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -1,124 +1,89 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"b" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"c" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"d" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/retractor{
-	pixel_y = 5
-	},
-/obj/item/hemostat,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"e" = (
-/obj/structure/table,
-/obj/item/cautery,
-/obj/item/surgicaldrill,
-/obj/item/circular_saw{
-	pixel_y = 9
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"f" = (
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"g" = (
-/obj/structure/shuttle/engine/propulsion/right{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"h" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"i" = (
-/obj/machinery/computer/emergency_shuttle,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"j" = (
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"k" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"l" = (
-/obj/structure/chair/comfy/shuttle,
+"aH" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"m" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
+"bn" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "security airlock";
+	req_access_txt = "63"
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"bH" = (
+/obj/structure/table/glass,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"cD" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"n" = (
-/obj/structure/table/optable,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"o" = (
+/obj/structure/window/reinforced,
 /obj/machinery/light{
 	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"cN" = (
+/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"p" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+"gZ" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"q" = (
-/obj/machinery/computer/communications{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
+"hv" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"r" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"s" = (
+"hx" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "bridge door";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"t" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
+"hP" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"u" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+"hT" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/escape)
-"v" = (
+"jt" = (
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"w" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
+"jx" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti{
+	name = "pasghetti";
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"x" = (
+"kf" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"km" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ls" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"mZ" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"os" = (
 /obj/structure/table,
 /obj/machinery/recharger{
 	active_power_usage = 0;
@@ -128,102 +93,28 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"y" = (
-/obj/structure/table,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/mineral/plastitanium/red/brig,
+"qU" = (
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"z" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "security airlock";
-	req_access_txt = "63"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"A" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"B" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"C" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"D" = (
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"E" = (
+"rg" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"F" = (
-/obj/structure/table,
+"tp" = (
+/obj/structure/chair/comfy/shuttle,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"G" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"H" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"I" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti{
-	name = "pasghetti";
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"J" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"K" = (
+"uU" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"L" = (
-/obj/structure/table,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"M" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"N" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"O" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"P" = (
+"vb" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -231,66 +122,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"Q" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"R" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"S" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"T" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"U" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/brute,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"V" = (
+"vl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"W" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"X" = (
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Y" = (
-/obj/structure/table/glass,
-/obj/item/defibrillator/loaded,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Z" = (
+"wB" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile/emergency{
 	dir = 8;
@@ -303,292 +141,466 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"ye" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ys" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"yK" = (
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/retractor{
+	pixel_y = 5
+	},
+/obj/item/hemostat,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"zX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"AN" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/brute,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"BE" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"CU" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"CX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Dw" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"FD" = (
+/obj/machinery/sleeper{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"FN" = (
+/turf/template_noop,
+/area/template_noop)
+"Gy" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Ll" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"LR" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Mf" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Mg" = (
+/obj/structure/table/optable,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Qd" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Qo" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"QP" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"RX" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Sq" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"TY" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"UZ" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Vz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"WH" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Xu" = (
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/surgicaldrill,
+/obj/item/circular_saw{
+	pixel_y = 9
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"XB" = (
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Yd" = (
+/obj/machinery/computer/communications{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"YQ" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Zl" = (
+/obj/structure/table,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 
 (1,1,1) = {"
-a
-a
-b
-b
-c
-b
-c
-c
-c
-c
-c
-b
-a
-a
+FN
+FN
+qU
+qU
+hT
+qU
+hT
+hT
+hT
+hT
+hT
+qU
+FN
+FN
 "}
 (2,1,1) = {"
-a
-b
-h
-q
-k
-c
-B
-H
-H
-H
-B
-h
-b
-a
+FN
+qU
+hv
+Yd
+RX
+hT
+mZ
+CX
+CX
+CX
+mZ
+hv
+qU
+FN
 "}
 (3,1,1) = {"
-a
-b
-i
-r
-C
-s
-C
-C
-C
-C
-C
-S
-b
-a
+FN
+qU
+Gy
+zX
+km
+hx
+km
+km
+km
+km
+km
+Sq
+qU
+FN
 "}
 (4,1,1) = {"
-a
-c
-j
-C
-v
-b
-D
-D
-L
-C
-C
-S
-b
-a
+FN
+hT
+ye
+km
+jt
+qU
+WH
+WH
+XB
+km
+km
+Sq
+qU
+FN
 "}
 (5,1,1) = {"
-a
-c
-j
-C
-V
-b
-E
-E
-M
-C
-C
-S
-b
-a
+FN
+hT
+ye
+km
+vl
+qU
+rg
+rg
+ys
+km
+km
+Sq
+qU
+FN
 "}
 (6,1,1) = {"
-a
-b
-k
-C
-k
-b
-F
-I
-L
-C
-C
-T
-h
-b
+FN
+qU
+RX
+km
+RX
+qU
+UZ
+jx
+XB
+km
+km
+kf
+hv
+qU
 "}
 (7,1,1) = {"
-a
-b
-b
-s
-c
-b
-C
-C
-C
-C
-C
-C
-B
-b
+FN
+qU
+qU
+hx
+hT
+qU
+km
+km
+km
+km
+km
+km
+mZ
+qU
 "}
 (8,1,1) = {"
-a
-b
-l
-t
-t
-c
-B
-C
-C
-C
-C
-C
-V
-b
+FN
+qU
+ls
+aH
+aH
+hT
+mZ
+km
+km
+km
+km
+km
+vl
+qU
 "}
 (9,1,1) = {"
-a
-b
-l
-t
-t
-z
-C
-C
-N
-P
-C
-C
-W
-c
+FN
+qU
+ls
+aH
+aH
+bn
+km
+km
+CU
+vb
+km
+km
+LR
+hT
 "}
 (10,1,1) = {"
-a
-b
-m
-t
-t
-c
-C
-C
-N
-P
-C
-C
-W
-c
+FN
+qU
+tp
+aH
+aH
+hT
+km
+km
+CU
+vb
+km
+km
+LR
+hT
 "}
 (11,1,1) = {"
-a
-b
-l
-t
-x
-b
-C
-C
-N
-P
-C
-C
-W
-c
+FN
+qU
+ls
+aH
+os
+qU
+km
+km
+CU
+vb
+km
+km
+LR
+hT
 "}
 (12,1,1) = {"
-a
-b
-l
-t
-y
-b
-C
-C
-O
-P
-C
-C
-B
-b
+FN
+qU
+ls
+aH
+Zl
+qU
+km
+km
+cD
+vb
+km
+km
+mZ
+qU
 "}
 (13,1,1) = {"
-b
-b
-b
-b
-b
-h
-C
-C
-w
-b
-A
-c
-b
-b
+qU
+qU
+qU
+qU
+qU
+hv
+km
+km
+Qd
+qU
+cN
+hT
+qU
+qU
 "}
 (14,1,1) = {"
-b
-d
-n
-f
-f
-A
-C
-C
-A
-Q
-f
-f
-X
-b
+qU
+yK
+Mg
+Mf
+Mf
+cN
+km
+km
+cN
+Vz
+Mf
+Mf
+FD
+qU
 "}
 (15,1,1) = {"
-b
-e
-f
-f
-f
-A
-C
-C
-A
-f
-f
-f
-f
-b
+qU
+Xu
+Mf
+Mf
+Mf
+cN
+km
+km
+cN
+Mf
+Mf
+Mf
+Mf
+qU
 "}
 (16,1,1) = {"
-b
-f
-o
-f
-b
-b
-G
-G
-b
-b
-R
-U
-Y
-b
+qU
+gZ
+Ll
+TY
+qU
+qU
+BE
+BE
+qU
+qU
+YQ
+AN
+bH
+qU
 "}
 (17,1,1) = {"
-b
-b
-b
-b
-b
-b
-C
-J
-b
-b
-b
-b
-b
-b
+qU
+qU
+qU
+qU
+qU
+qU
+km
+hP
+qU
+qU
+qU
+qU
+qU
+qU
 "}
 (18,1,1) = {"
-b
-g
-p
-u
-b
-b
-K
-Z
-b
-b
-g
-p
-u
-b
+qU
+QP
+Dw
+Qo
+qU
+qU
+uU
+wB
+qU
+qU
+QP
+Dw
+Qo
+qU
 "}

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -333,9 +333,8 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bs" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/machinery/shower{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -369,6 +368,10 @@
 /area/shuttle/escape)
 "XC" = (
 /obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ZW" = (
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 
@@ -608,7 +611,7 @@ aR
 ac
 bd
 be
-bd
+ZW
 ad
 ad
 "}

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1219,7 +1219,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cE" = (
@@ -1716,6 +1716,16 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"kj" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "pf" = (
 /obj/machinery/vending/wallmed{
@@ -2477,7 +2487,7 @@ cs
 cp
 cp
 cp
-cw
+kj
 ab
 cR
 cY

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -325,12 +325,22 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"dO" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
 "tt" = (
 /obj/machinery/door/airlock/bananium{
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"vK" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "Jq" = (
 /obj/machinery/door/airlock/bananium{
@@ -511,7 +521,7 @@ aN
 ak
 ac
 Zf
-aY
+vK
 Zf
 bf
 bg
@@ -584,7 +594,7 @@ aL
 ac
 aX
 bb
-aX
+dO
 ab
 ab
 "}

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -87,6 +87,7 @@
 	pixel_x = 5;
 	pixel_y = 10
 	},
+/obj/item/toy/plush/moth,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cu" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -493,7 +493,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/sleeper,
+/obj/machinery/sleeper{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "aR" = (
@@ -1380,6 +1382,16 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
+"rP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/stasis,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -1887,7 +1899,7 @@ aB
 aG
 aJ
 aN
-aQ
+rP
 aP
 aZ
 bd

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -461,6 +461,10 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"bx" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "bS" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/item/clothing/suit/apron/surgical,
@@ -848,7 +852,7 @@ aW
 aX
 aY
 ab
-bf
+bx
 bk
 bq
 ab

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -24,6 +24,10 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
+"g" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "h" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -183,6 +187,9 @@
 /area/shuttle/escape)
 "R" = (
 /obj/machinery/light/small,
+/obj/machinery/shower{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "S" = (
@@ -271,7 +278,7 @@ c
 d
 q
 v
-q
+g
 d
 H
 H

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -144,6 +144,9 @@
 /area/shuttle/escape)
 "y" = (
 /obj/item/kirbyplants,
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "z" = (

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -706,6 +706,11 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"jb" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/stasis,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "kS" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -975,10 +980,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/shower{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -1285,7 +1288,7 @@ cb
 bK
 ci
 cm
-Ui
+jb
 hE
 Lf
 da

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -624,6 +624,9 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
+/obj/machinery/shower{
+	pixel_y = 18
+	},
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "cb" = (
@@ -948,6 +951,10 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/luxury)
+"IX" = (
+/obj/machinery/stasis,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "Lt" = (
 /obj/machinery/door/airlock/security/glass{
@@ -1376,7 +1383,7 @@ bi
 bl
 bv
 ag
-cb
+IX
 ce
 cm
 ag

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -839,6 +839,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"DE" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "Ew" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -1127,7 +1131,7 @@ ar
 LY
 aE
 ac
-bl
+DE
 bl
 Vs
 bK

--- a/_maps/shuttles/emergency_midway.dmm
+++ b/_maps/shuttles/emergency_midway.dmm
@@ -326,6 +326,12 @@
 "rc" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
+"rq" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "to" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -584,7 +590,7 @@ aN
 aG
 aG
 aE
-az
+rq
 zS
 aQ
 aN

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -63,6 +63,9 @@
 	name = "Emergency NanoMed";
 	pixel_x = 28
 	},
+/obj/machinery/shower{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "m" = (
@@ -167,7 +170,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "G" = (
-/obj/structure/table/optable,
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "H" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -591,7 +591,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bd" = (

--- a/_maps/shuttles/emergency_packed.dmm
+++ b/_maps/shuttles/emergency_packed.dmm
@@ -172,7 +172,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "C" = (
-/obj/structure/table/optable,
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "D" = (
@@ -280,6 +280,12 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"Z" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 i
@@ -316,7 +322,7 @@ T
 q
 T
 D
-z
+Z
 C
 T
 "}

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -491,6 +491,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bf" = (
@@ -522,14 +525,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bj" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -582,7 +582,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 28
 	},
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -647,6 +647,10 @@
 "by" = (
 /obj/machinery/iv_drip,
 /obj/structure/bed/roller,
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -500,6 +500,9 @@
 "bJ" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bK" = (
@@ -562,6 +565,11 @@
 "wq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/optable,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"AE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/stasis,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ev" = (
@@ -875,7 +883,7 @@ ax
 ac
 bB
 bB
-bD
+AE
 ad
 ad
 "}

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -507,6 +507,22 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"oc" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"uP" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"BX" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "Ec" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -644,11 +660,11 @@ ab
 ab
 ab
 ab
-aq
+BX
 aK
 aN
-aK
-aq
+uP
+oc
 ab
 ji
 ji

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -410,6 +410,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
+"jB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -503,7 +510,7 @@ ab
 "}
 (6,1,1) = {"
 ab
-ag
+jB
 al
 al
 aq
@@ -539,7 +546,7 @@ ar
 "}
 (8,1,1) = {"
 ab
-ag
+jB
 ag
 ag
 aq

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -2722,6 +2722,9 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "engine fuel pump"
 	},
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "vk" = (

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -42,8 +42,8 @@
 "ah" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
-	dir = 4
+	dir = 4;
+	icon_state = "tube-broken"
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/airless,
@@ -69,15 +69,15 @@
 /area/shuttle/abandoned)
 "am" = (
 /obj/structure/shuttle/engine/propulsion/right{
-	icon_state = "propulsion_r";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion_r"
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "an" = (
 /obj/structure/shuttle/engine/propulsion/left{
-	icon_state = "propulsion_l";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion_l"
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -154,8 +154,8 @@
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil,
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
-	dir = 4
+	dir = 4;
+	icon_state = "tube-broken"
 	},
 /turf/open/floor/plasteel/airless,
 /area/shuttle/abandoned)
@@ -222,12 +222,10 @@
 /area/shuttle/abandoned)
 "aM" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/urinal{
-	dir = 8;
-	icon_state = "urinal";
-	pixel_x = 32
-	},
 /obj/structure/window/reinforced/tinted,
+/obj/machinery/shower{
+	dir = 8
+	},
 /turf/open/floor/plasteel/airless/showroomfloor,
 /area/shuttle/abandoned)
 "aN" = (
@@ -332,8 +330,8 @@
 "ba" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack{
-	icon_state = "paperstack";
-	dir = 4
+	dir = 4;
+	icon_state = "paperstack"
 	},
 /obj/item/folder/yellow,
 /turf/open/floor/plasteel/airless,
@@ -415,8 +413,8 @@
 "bk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack{
-	icon_state = "paperstack";
-	dir = 1
+	dir = 1;
+	icon_state = "paperstack"
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -438,8 +436,8 @@
 "bm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack{
-	icon_state = "paperstack";
-	dir = 8
+	dir = 8;
+	icon_state = "paperstack"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -482,8 +480,8 @@
 /area/shuttle/abandoned)
 "br" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	icon_state = "computer";
-	dir = 1
+	dir = 1;
+	icon_state = "computer"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/disk/holodisk/donutstation/whiteship,

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -1112,6 +1112,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/shower{
+	pixel_y = 18
+	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/abandoned/cargo)
 "sD" = (

--- a/_maps/shuttles/whiteship_midway.dmm
+++ b/_maps/shuttles/whiteship_midway.dmm
@@ -2173,6 +2173,9 @@
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
 "QU" = (
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "QV" = (

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -609,6 +609,9 @@
 "xV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "yn" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Showers to shuttles and stasis

## Why It's Good For The Game
makes shuttles up to boomer standards
and ends the stigmatism towards Plasmemes
whiteships now have showers in the engine room

## Changelog
:cl:
add: Added Showers And Stasis beds in the medical part of shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
