### PR TITLE
Syndicate re-arms their loneop division.

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -230,7 +230,7 @@
 	var/intern_outfit = /datum/outfit/syndicate/intern
 
 /datum/antagonist/nukeop/lone/on_gain()
-	nukeop_outfit = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE) ? intern_outfit : nukeop_outfit
+	nukeop_outfit = (get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE) <= intern_pop_max) ? intern_outfit : nukeop_outfit
 	..()		//WS Edit End
 
 /datum/antagonist/nukeop/lone/assign_nuke()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug where fully armed loneops would only spawn with a player count of 0, and Jakeops otherwise.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #683
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Full loneops spawn at 10 players again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
