### PR TITLE
Landing Field Designator can target Whitesands and Ice Moon surface for Aux Base

### DIFF
--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -156,7 +156,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 			var/turf/place = colony_turfs[i]
 			if(!place)
 				return BAD_COORDS
-			if(!istype(place.loc, /area/lavaland/surface))
+			if(!istype(place.loc, /area/lavaland/surface) && !istype(place.loc, /area/whitesands/surface) && !istype(place.loc, /area/icemoon/surface))
 				return BAD_AREA
 			if(disallowed_turf_types[place.type])
 				return BAD_TURF

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -156,7 +156,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 			var/turf/place = colony_turfs[i]
 			if(!place)
 				return BAD_COORDS
-			if(!istype(place.loc, /area/lavaland/surface) && !istype(place.loc, /area/whitesands/surface) && !istype(place.loc, /area/icemoon/surface))
+			if(!istype(place.loc, /area/lavaland/surface) && !istype(place.loc, /area/whitesands/surface) && !istype(place.loc, /area/icemoon/surface))  // WaspStation Edit - LFD can target all mining maps
 				return BAD_AREA
 			if(disallowed_turf_types[place.type])
 				return BAD_TURF


### PR DESCRIPTION
## About The Pull Request

Previously the landing field designator would pass back failure if used anywhere other than lavaland.  I just changed the conditional to also allow whitesands and the ice moon's surface level.  I confirmed that it continues to fail in the ice moon's underground level.

## Why It's Good For The Game

Bug Fix.  This was clearly an oversight.  Aux base works on all mining maps.

## Changelog
:cl
fix: Landing field designator can now target Whitesands and Ice Moon surface for aux base
/:cl:
