### PR TITLE
Emergency holopad mapping for Boxstation and also a few touchups here and there

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/budget.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/budget.dmm
@@ -59,6 +59,10 @@
 "df" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"do" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -93,6 +97,22 @@
 /obj/machinery/power/smes,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ed" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -119,7 +139,7 @@
 "fc" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -134,21 +154,6 @@
 "gK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ha" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -1172,7 +1177,7 @@ TA
 iM
 bn
 ZC
-ZC
+fc
 Ok
 nB
 ZC
@@ -1371,7 +1376,7 @@ ho
 wb
 Bs
 Nz
-ha
+ed
 Nz
 Bs
 wb
@@ -1564,7 +1569,7 @@ CK
 hH
 Nq
 ZC
-fc
+ZC
 Et
 Fz
 ZC
@@ -1598,7 +1603,7 @@ oq
 ZC
 ZC
 ZC
-ZC
+do
 ZC
 ZC
 Qd
@@ -1622,7 +1627,7 @@ eE
 oT
 Zl
 CK
-ZC
+fc
 ZC
 ZC
 ZC
@@ -1650,7 +1655,7 @@ eE
 Pp
 ZC
 WW
-fc
+ZC
 ZC
 sz
 EV

--- a/_maps/RandomRuins/StationRuins/Box/Engine/empty.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/empty.dmm
@@ -147,7 +147,7 @@
 "vY" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -173,6 +173,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"yj" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "yC" = (
@@ -664,7 +668,7 @@ Oo
 wQ
 cd
 Jc
-Jc
+vY
 Om
 Ve
 Jc
@@ -865,7 +869,7 @@ Jc
 Jc
 Jc
 Jc
-Jc
+yj
 Jc
 Jc
 Jc
@@ -1056,7 +1060,7 @@ iV
 ci
 Jc
 Jc
-vY
+Jc
 Kw
 kh
 Jc
@@ -1114,7 +1118,7 @@ SD
 Uv
 UK
 iV
-Jc
+vY
 Jc
 Jc
 Jc
@@ -1142,7 +1146,7 @@ SD
 cP
 Jc
 qx
-vY
+Jc
 Jc
 Kw
 Jc

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_am.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_am.dmm
@@ -537,6 +537,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"NK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/holopad,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "Ok" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1180,7 +1185,7 @@ Ok
 Uw
 Qw
 pF
-hv
+NK
 Xf
 dk
 dk

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_singulo.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_singulo.dmm
@@ -3,6 +3,18 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"aP" = (
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -171,13 +183,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "nn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/emitter/welded,
@@ -189,6 +194,16 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"oa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "pK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -270,6 +285,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"ty" = (
+/obj/machinery/light,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - South";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "tZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -286,14 +311,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"uI" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - East";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "uU" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -471,6 +488,15 @@
 /obj/item/flashlight,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"Dr" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - West";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "El" = (
 /obj/effect/turf_decal/stripes/line,
@@ -693,15 +719,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"MU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "Oo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -811,6 +828,15 @@
 "Sa" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"Sj" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - East";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "Ss" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -886,15 +912,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"VR" = (
-/obj/machinery/light,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - South";
-	dir = 1;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "Wg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -932,14 +949,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"XY" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - West";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Yg" = (
 /obj/machinery/door/airlock/external{
@@ -1224,7 +1233,7 @@ lz
 lz
 lz
 lz
-XY
+Dr
 lz
 lz
 lz
@@ -1274,7 +1283,7 @@ XF
 mA
 QC
 Pt
-lz
+aP
 lz
 aI
 ky
@@ -1469,9 +1478,9 @@ Fk
 Fh
 wf
 eD
-nc
+bj
 vN
-MU
+oa
 Sa
 Sa
 Sa
@@ -1483,7 +1492,7 @@ Sa
 Sa
 OV
 aI
-VR
+ty
 Pt
 KX
 ky
@@ -1666,7 +1675,7 @@ yh
 Gm
 pK
 Pt
-lz
+aP
 ky
 aI
 ky
@@ -1728,7 +1737,7 @@ lz
 lz
 lz
 lz
-uI
+Sj
 lz
 lz
 lz

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm.dmm
@@ -258,17 +258,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"hg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -416,6 +405,17 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"lz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -426,6 +426,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/engine,
+/area/engine/engineering)
+"mj" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -533,6 +540,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oy" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oP" = (
@@ -958,23 +978,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"yG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "zq" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1265,7 +1268,7 @@
 "HK" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -1294,16 +1297,11 @@
 "Id" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
-"Jv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+"IT" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "JE" = (
@@ -1325,6 +1323,14 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/engine,
+/area/engine/engineering)
+"JX" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "Kb" = (
 /obj/effect/turf_decal/stripes/line,
@@ -1494,6 +1500,19 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
 	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"Ot" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "OF" = (
@@ -1856,18 +1875,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"Vj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "VK" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -1996,6 +2003,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"XH" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "XS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -2366,7 +2389,7 @@ DN
 VU
 yb
 cG
-cG
+lz
 cG
 VP
 fG
@@ -2392,13 +2415,13 @@ Go
 (12,1,1) = {"
 oS
 XW
-Jv
+oy
 yg
 yg
 yg
 yg
 Up
-yg
+IT
 yg
 Yq
 yg
@@ -2533,7 +2556,7 @@ Go
 Yo
 qL
 hk
-yG
+XH
 iX
 DK
 up
@@ -2571,7 +2594,7 @@ eF
 ER
 uY
 QK
-QK
+JX
 bo
 nF
 TP
@@ -2728,13 +2751,13 @@ Go
 (24,1,1) = {"
 hV
 qh
-Vj
+Ot
 qY
 yg
 yg
 yg
 Ki
-yg
+IT
 yg
 vF
 yg
@@ -2743,7 +2766,7 @@ fg
 Xf
 lG
 TP
-HK
+mj
 TP
 GD
 iI
@@ -2758,7 +2781,7 @@ bo
 ax
 NO
 We
-hg
+LU
 LU
 jd
 yp
@@ -2816,7 +2839,7 @@ zZ
 ft
 rZ
 bo
-TP
+HK
 qH
 Tu
 Tu
@@ -2844,7 +2867,7 @@ zZ
 sm
 Cj
 ds
-HK
+TP
 QQ
 WW
 yy

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_1x3.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_1x3.dmm
@@ -94,17 +94,6 @@
 "cr" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -294,18 +283,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"lj" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -633,6 +610,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"ty" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -744,6 +734,24 @@
 /obj/structure/rack,
 /obj/item/flashlight,
 /turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"wH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"wQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "xi" = (
 /obj/structure/cable{
@@ -986,18 +994,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"Dj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "Dp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -1029,6 +1025,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"DQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "Ed" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -1056,6 +1060,13 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"EE" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "EI" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -1283,7 +1294,7 @@
 "JL" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -1354,6 +1365,20 @@
 "LF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"LG" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1714,21 +1739,6 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"SL" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "SN" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -1811,6 +1821,19 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"Vx" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "VA" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -1925,6 +1948,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"Xk" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "Xz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2291,7 +2318,7 @@ na
 Wg
 LB
 Hr
-Hr
+wH
 Hr
 uV
 Ax
@@ -2317,13 +2344,13 @@ GC
 (12,1,1) = {"
 IX
 ba
-lj
+Vx
 xi
 xi
 xi
 xi
 Oo
-xi
+wQ
 xi
 QQ
 xi
@@ -2459,7 +2486,7 @@ Mn
 id
 Uu
 QV
-SL
+LG
 gk
 yM
 pE
@@ -2496,13 +2523,13 @@ hg
 RW
 QC
 OS
-OS
+DQ
 TW
 xm
 Ir
 xm
 dL
-Ir
+Xk
 iq
 GC
 NO
@@ -2653,13 +2680,13 @@ GC
 (24,1,1) = {"
 Mb
 bM
-Dj
+ty
 mJ
 xi
 xi
 xi
 FB
-xi
+wQ
 xi
 Zu
 xi
@@ -2668,7 +2695,7 @@ cx
 MB
 PZ
 Ir
-JL
+EE
 Ir
 wq
 iq
@@ -2683,7 +2710,7 @@ TW
 Pm
 WG
 iR
-cw
+oj
 oj
 FT
 DP
@@ -2741,7 +2768,7 @@ dn
 rl
 rY
 TW
-Ir
+JL
 eA
 NR
 NR
@@ -2769,7 +2796,7 @@ dn
 EA
 cr
 hV
-JL
+Ir
 rw
 xY
 xF

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_3x.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_3x.dmm
@@ -12,6 +12,14 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"bc" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "bp" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -264,6 +272,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"hd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -457,6 +481,19 @@
 /obj/structure/table,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"lz" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "lG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -851,18 +888,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1060,6 +1085,13 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"AQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Bp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1187,6 +1219,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"Dz" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "DF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1345,17 +1384,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"GP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
@@ -1378,25 +1406,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"Hk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Hm" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"Hp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+"Hw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine");
-	pixel_x = 23
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Hy" = (
@@ -1429,18 +1464,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"Ip" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1959,7 +1982,7 @@
 "XD" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -2331,7 +2354,7 @@ ys
 kl
 IA
 MX
-MX
+Hk
 MX
 gq
 Ez
@@ -2357,13 +2380,13 @@ pR
 (12,1,1) = {"
 NL
 Pm
-Ip
+lz
 eP
 eP
 eP
 eP
 VL
-eP
+AQ
 eP
 wA
 eP
@@ -2498,7 +2521,7 @@ pR
 lO
 Bp
 go
-Hp
+hd
 OS
 Qo
 YE
@@ -2536,7 +2559,7 @@ pA
 eB
 Ne
 Hy
-Hy
+bc
 Hm
 aN
 aN
@@ -2693,13 +2716,13 @@ pR
 (24,1,1) = {"
 zj
 Qn
-vM
+Hw
 is
 eP
 eP
 eP
 sX
-eP
+AQ
 eP
 vJ
 eP
@@ -2708,7 +2731,7 @@ JP
 wM
 HU
 aN
-XD
+Dz
 aN
 kn
 Ax
@@ -2723,7 +2746,7 @@ Hm
 Ev
 Zk
 gT
-GP
+Ft
 Ft
 gE
 tM
@@ -2781,7 +2804,7 @@ tG
 yh
 Ef
 Hm
-aN
+XD
 GH
 yg
 yg
@@ -2809,7 +2832,7 @@ tG
 Pi
 Su
 bt
-XD
+aN
 wg
 Eq
 Bq

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_5x5.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_5x5.dmm
@@ -18,6 +18,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -49,6 +59,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cJ" = (
@@ -260,32 +277,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"hB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"hF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -641,6 +632,20 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"qG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/holopad,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -825,16 +830,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"tV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ud" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -916,6 +911,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"vL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wa" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -933,18 +938,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xj" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -957,6 +950,25 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"yj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "yw" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -1405,26 +1417,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"HU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "Ip" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1584,14 +1576,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"Lj" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "LB" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -1673,7 +1657,7 @@
 "MM" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -1892,6 +1876,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"Rx" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -1915,6 +1908,17 @@
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
+/area/engine/engineering)
+"Su" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "Sx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -1991,6 +1995,15 @@
 "TT" = (
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"Uf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Uq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Gas to Chamber"
@@ -2025,6 +2038,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"Wx" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "WY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2453,7 +2473,7 @@ zE
 rI
 ch
 ei
-ei
+Su
 ei
 DR
 Tr
@@ -2479,13 +2499,13 @@ JG
 (12,1,1) = {"
 fI
 HM
-hB
-Vt
+qG
+Uf
 Vt
 Vt
 Vt
 BZ
-Vt
+cB
 Vt
 to
 Vt
@@ -2619,7 +2639,7 @@ JG
 (17,1,1) = {"
 jn
 do
-HU
+yj
 Kf
 QW
 EC
@@ -2658,7 +2678,7 @@ TT
 TT
 QC
 PA
-Lj
+Rx
 Kg
 yB
 jI
@@ -2815,13 +2835,13 @@ JG
 (24,1,1) = {"
 XI
 fJ
-wZ
+vL
 Mf
 Vt
 Vt
 Vt
 kb
-Vt
+cB
 Vt
 aE
 Vt
@@ -2830,7 +2850,7 @@ nv
 JK
 Jh
 yB
-MM
+Wx
 yB
 rn
 HG
@@ -2843,9 +2863,9 @@ JG
 (25,1,1) = {"
 Kg
 uk
-tV
+aJ
 hQ
-hF
+Vs
 Vs
 PV
 nt
@@ -2903,7 +2923,7 @@ yW
 xj
 Qy
 Kg
-yB
+MM
 tK
 iK
 iK
@@ -2931,7 +2951,7 @@ yW
 uF
 YU
 fB
-MM
+yB
 lU
 iP
 Dj

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
@@ -289,6 +289,17 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/bot_assembly/firebot,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ha" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
@@ -302,7 +313,7 @@
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -315,6 +326,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"hT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ih" = (
@@ -462,6 +478,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lk" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -524,25 +556,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ns" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"nR" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -590,16 +617,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/item/bot_assembly/firebot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -621,12 +638,8 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qh" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/delivery,
+"qz" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qC" = (
@@ -858,6 +871,20 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"yN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -964,6 +991,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"CX" = (
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Dd" = (
@@ -1452,12 +1483,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"OY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -1664,21 +1689,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"Ti" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "TB" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/turf_decal/delivery,
@@ -1705,6 +1715,13 @@
 	dir = 4
 	},
 /turf/closed/wall,
+/area/engine/engineering)
+"UK" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "UL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -2275,7 +2292,7 @@ Dd
 vc
 vc
 jv
-Dd
+qz
 od
 Hz
 li
@@ -2341,7 +2358,7 @@ yS
 yS
 Nf
 WL
-Dd
+qz
 Dd
 eC
 KN
@@ -2366,7 +2383,7 @@ Jk
 jT
 wt
 uG
-ns
+yN
 wt
 wt
 wt
@@ -2451,7 +2468,7 @@ xt
 Fb
 Dd
 Gr
-pb
+gS
 fy
 DB
 uz
@@ -2472,7 +2489,7 @@ Te
 XF
 yS
 UI
-Ti
+lk
 cr
 Mr
 Dd
@@ -2584,7 +2601,7 @@ FN
 vY
 AP
 GF
-cr
+hT
 fE
 fE
 ka
@@ -2638,7 +2655,7 @@ Dj
 AN
 cB
 sq
-Gr
+nR
 Dd
 QT
 Ba
@@ -2666,8 +2683,8 @@ Dj
 RO
 Dd
 Gf
-qh
-OY
+CX
+UK
 Ax
 Gk
 ci

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
@@ -25,12 +25,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"bX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "ca" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -66,12 +60,29 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ck" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"cx" = (
+/obj/machinery/light,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - South";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cH" = (
 /obj/machinery/door/airlock/external{
@@ -112,6 +123,10 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"fv" = (
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "fD" = (
 /obj/effect/turf_decal/stripes/line{
@@ -163,14 +178,6 @@
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"ik" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - West";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "iD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -577,6 +584,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"wF" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - East";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -653,13 +669,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"zM" = (
-/obj/machinery/light,
+"AG" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Engine - South";
-	dir = 1;
+	c_tag = "Engine - West";
+	dir = 4;
 	network = list("ss13","engine")
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Bz" = (
@@ -767,14 +783,6 @@
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"HI" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - East";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "HO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1367,7 +1375,7 @@ zi
 zi
 zi
 zi
-ik
+AG
 zi
 zi
 zi
@@ -1417,7 +1425,7 @@ Dz
 ok
 gE
 eN
-zi
+fv
 zi
 CB
 rk
@@ -1614,7 +1622,7 @@ iP
 lM
 VU
 Qg
-bX
+ck
 cc
 ww
 NK
@@ -1626,7 +1634,7 @@ HA
 fO
 Lw
 CB
-zM
+cx
 eN
 vD
 rk
@@ -1809,7 +1817,7 @@ Me
 Cw
 fD
 eN
-zi
+fv
 zi
 CB
 rk
@@ -1871,7 +1879,7 @@ zi
 zi
 zi
 zi
-HI
+wF
 zi
 zi
 zi

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
@@ -60,29 +60,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"ck" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"cx" = (
-/obj/machinery/light,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - South";
-	dir = 1;
-	network = list("ss13","engine")
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cH" = (
 /obj/machinery/door/airlock/external{
@@ -123,10 +106,6 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
-"fv" = (
-/obj/machinery/holopad,
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "fD" = (
 /obj/effect/turf_decal/stripes/line{
@@ -560,6 +539,14 @@
 "vg" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
+"vw" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - East";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vD" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -583,15 +570,6 @@
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
-"wF" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - East";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "wP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -667,15 +645,6 @@
 	c_tag = "Engine - North West";
 	network = list("ss13","engine")
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"AG" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine - West";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/obj/machinery/holopad,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Bz" = (
@@ -808,6 +777,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"Jt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "Jz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -898,6 +873,15 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"MZ" = (
+/obj/machinery/light,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - South";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Nm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1125,6 +1109,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"ZR" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine - West";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ZZ" = (
 /obj/structure/lattice/catwalk,
@@ -1375,7 +1367,7 @@ zi
 zi
 zi
 zi
-AG
+ZR
 zi
 zi
 zi
@@ -1425,7 +1417,7 @@ Dz
 ok
 gE
 eN
-fv
+zi
 zi
 CB
 rk
@@ -1622,7 +1614,7 @@ iP
 lM
 VU
 Qg
-ck
+Jt
 cc
 ww
 NK
@@ -1634,7 +1626,7 @@ HA
 fO
 Lw
 CB
-cx
+MZ
 eN
 vD
 rk
@@ -1817,7 +1809,7 @@ Me
 Cw
 fD
 eN
-fv
+zi
 zi
 CB
 rk
@@ -1879,7 +1871,7 @@ zi
 zi
 zi
 zi
-wF
+vw
 zi
 zi
 zi

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11938,6 +11938,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"aWJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "aXf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12252,10 +12258,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -23
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"aYL" = (
-/obj/machinery/light,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aYM" = (
@@ -13413,11 +13415,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bes" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bet" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -25765,6 +25762,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"crT" = (
+/obj/structure/light_construct/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "crX" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -28834,12 +28838,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"dNM" = (
-/obj/structure/light_construct/small{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/maintenance/department/crew_quarters/bar)
 "dOe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -29253,6 +29251,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"eeV" = (
+/obj/effect/landmark/xeno_spawn,
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "efi" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -29286,6 +29290,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"egp" = (
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/wood,
+/area/maintenance/department/crew_quarters/bar)
 "egq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -32650,6 +32661,13 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"gtY" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "gud" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -34938,6 +34956,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hVV" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hWH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35746,14 +35772,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
-"iFS" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "iGy" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
@@ -36872,6 +36890,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jwJ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "jwN" = (
 /obj/effect/landmark/start/brig_phys,
 /turf/open/floor/plasteel/white,
@@ -37594,6 +37620,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jUi" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jUp" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -38242,11 +38281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"ktL" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "kum" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38280,6 +38314,11 @@
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kvP" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "kwq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -39832,6 +39871,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lyQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/maintenance/department/crew_quarters/bar)
 "lze" = (
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -40109,6 +40152,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lIK" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/maintenance/department/crew_quarters/bar)
 "lIQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42089,11 +42137,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"mQV" = (
-/obj/effect/landmark/xeno_spawn,
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
-/turf/open/floor/carpet/green,
-/area/maintenance/department/crew_quarters/bar)
 "mRc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/break_room";
@@ -43018,6 +43061,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"nrG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "nrJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -43114,6 +43161,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nuW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "nvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45787,12 +45844,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"piw" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/green,
-/area/maintenance/department/crew_quarters/bar)
 "piA" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -47754,6 +47805,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/head_of_personnel)
+"qtN" = (
+/obj/machinery/light,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "quy" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -49999,6 +50057,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sbs" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sbD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -53146,6 +53212,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uht" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "uhG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -54677,22 +54762,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
-"vaZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "vbl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -54745,6 +54814,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vde" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "vdt" = (
 /obj/machinery/light{
 	dir = 8
@@ -81318,7 +81396,7 @@ bHE
 bHE
 bCq
 deV
-dNM
+crT
 jrV
 awX
 ylY
@@ -81575,7 +81653,7 @@ bCq
 bCq
 bRz
 eRK
-mQV
+eeV
 dIG
 utd
 icl
@@ -81830,10 +81908,10 @@ bHE
 bCq
 fet
 fet
-dIG
-dIG
-dIG
-dIG
+nrG
+nrG
+nrG
+nrG
 awX
 hRQ
 gpV
@@ -82346,7 +82424,7 @@ fet
 fet
 qQH
 ptM
-qQH
+lIK
 qQH
 fet
 fet
@@ -82600,14 +82678,14 @@ bCq
 muB
 bCq
 uSR
-ktL
+aWJ
 fet
 huW
 gtk
+lyQ
 fet
-fet
-jaR
-fet
+kvP
+lyQ
 fet
 bLv
 uAD
@@ -82856,15 +82934,15 @@ aaa
 tUv
 eiO
 olD
-piw
-dIG
+gtY
+nrG
 jbL
 qAk
 qAk
-iFS
+vde
 jaR
 iLQ
-jaR
+kvP
 fet
 bLv
 uAD
@@ -83114,13 +83192,13 @@ tUv
 vkx
 bCq
 dIG
-fet
+lyQ
 rih
 qAk
 qAk
 sBx
-fet
-jaR
+lyQ
+kvP
 fet
 fet
 bLv
@@ -83372,11 +83450,11 @@ vkx
 bCq
 qwF
 xkU
-fet
+egp
 qvl
 qvl
 fet
-fet
+lyQ
 fet
 vkk
 euO
@@ -84621,7 +84699,7 @@ aYl
 aYl
 aYl
 aYl
-aYl
+sbs
 bgG
 cWG
 aYl
@@ -85377,7 +85455,7 @@ jIG
 dTl
 jIG
 ayL
-aJs
+jUi
 edR
 aOE
 jOW
@@ -94106,7 +94184,7 @@ avy
 avy
 axS
 azk
-vaZ
+uht
 arj
 aCf
 aDY
@@ -94643,7 +94721,7 @@ aQc
 aQg
 aYV
 hfE
-bes
+hVV
 bfF
 bfF
 bXg
@@ -97465,7 +97543,7 @@ aSK
 aVz
 aVz
 aVz
-aYL
+qtN
 aJI
 bbz
 aYV
@@ -97701,7 +97779,7 @@ aaf
 arj
 auz
 avC
-avC
+nuW
 aya
 arj
 arA
@@ -101316,7 +101394,7 @@ aNQ
 aOZ
 aOX
 aOX
-aOX
+jwJ
 aUz
 aVM
 aOX

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -301,17 +301,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"abk" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 10
-	},
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Security"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "abl" = (
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
@@ -622,27 +611,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"abS" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"abU" = (
-/obj/machinery/computer/card/minor/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"abW" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "abY" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -679,13 +647,6 @@
 /obj/vehicle/ridden/secway,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"acj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "ack" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -698,17 +659,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"acn" = (
-/obj/item/storage/secure/safe/HoS{
-	pixel_x = 35
-	},
-/obj/structure/closet/secure_closet/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"aco" = (
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "acp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/showroomfloor,
@@ -718,17 +668,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"acr" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"act" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"acu" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "acv" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -891,25 +830,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"acQ" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/stamp/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"acR" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "acU" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -1048,12 +968,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"adn" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "adq" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar{
@@ -1064,6 +978,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"adr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/crew_quarters/bar)
 "ads" = (
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -2472,21 +2392,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"ahW" = (
-/obj/machinery/camera{
-	c_tag = "Brig Infirmary";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/brig_phys,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "ahX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2720,17 +2625,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aiL" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aiO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3232,14 +3126,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aks" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "akt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3356,17 +3242,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"akY" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Treatment Center";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
-/obj/machinery/sleeper{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
 "alb" = (
 /obj/structure/chair{
 	dir = 4;
@@ -3520,23 +3395,6 @@
 	pixel_x = -28;
 	pixel_y = -8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"alA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alB" = (
@@ -3983,6 +3841,12 @@
 "anf" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"anh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "anj" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
 	dir = 8
@@ -6778,6 +6642,12 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aAw" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "aAx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -7591,24 +7461,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"aEA" = (
-/obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	dir = 1;
-	name = "Chief Medical Officer RC";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "aEB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -7657,13 +7509,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
-"aEJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aEK" = (
@@ -7750,16 +7595,6 @@
 "aEZ" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"aFa" = (
-/obj/machinery/suit_storage_unit/cmo,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "aFb" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9002,11 +8837,6 @@
 "aJw" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
-"aJx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aJy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -9242,12 +9072,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
-"aKz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aKB" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -9705,12 +9529,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aMi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aMj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -9958,12 +9776,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aNr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aNt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -10296,10 +10108,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"aOS" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/library)
 "aOT" = (
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
@@ -10904,93 +10712,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aRi" = (
-/obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRj" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/obj/item/storage/box/PDAs{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/ids,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRl" = (
-/obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRm" = (
-/obj/machinery/computer/communications,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRn" = (
-/obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRo" = (
-/obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRq" = (
-/obj/machinery/computer/med_data,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRr" = (
-/obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aRs" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/item/wrench,
-/obj/item/assembly/timer,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/turf/open/floor/plasteel,
-/area/bridge)
 "aRt" = (
 /obj/machinery/light{
 	dir = 4
@@ -11162,9 +10883,6 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/engine/cult,
 /area/library)
-"aRS" = (
-/turf/open/floor/carpet,
-/area/chapel/main)
 "aRU" = (
 /obj/machinery/light{
 	dir = 1
@@ -11270,80 +10988,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"aSu" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSv" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSx" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Engineering Station"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSy" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Command Station"
-	},
-/obj/machinery/button/door{
-	id = "bridge blast";
-	name = "Bridge Blast Door Control";
-	pixel_x = 28;
-	pixel_y = -2;
-	req_access_txt = "19"
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 29;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSz" = (
-/obj/structure/table/reinforced,
-/obj/item/aicard,
-/obj/item/multitool,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSA" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSC" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSD" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Crew Station"
-	},
-/obj/effect/landmark/start/lieutenant,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aSE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel,
-/area/bridge)
 "aSF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -11734,93 +11378,6 @@
 "aTQ" = (
 /turf/closed/wall,
 /area/bridge)
-"aTR" = (
-/obj/machinery/computer/prisoner/management,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aTS" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aTT" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aTU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aTV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aTX" = (
-/turf/open/floor/plasteel,
-/area/bridge)
-"aTY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aUa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aUb" = (
-/obj/machinery/modular_computer/console/preset/engineering,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aUc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aUd" = (
-/obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aUe" = (
-/obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "aUf" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -12094,19 +11651,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
-"aVe" = (
-/obj/machinery/camera{
-	c_tag = "Bridge West";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "aVf" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light{
@@ -12118,19 +11662,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"aVr" = (
-/obj/machinery/camera{
-	c_tag = "Bridge East";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "aVv" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East Entrance"
@@ -12305,36 +11836,6 @@
 /obj/structure/spacepoddoor,
 /turf/open/floor/engine/airless,
 /area/escapepodbay)
-"aVY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
-"aWb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
-"aWd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/library)
-"aWg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "aWh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -12437,61 +11938,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"aWM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aWP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aWT" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Bridge";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aWW" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/bridge";
-	name = "Bridge APC";
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/bridge)
-"aWY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "aXf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12579,12 +12025,6 @@
 /obj/machinery/lapvend,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aXu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "aXv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -12600,13 +12040,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aXz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/chapel/main)
 "aXA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/corner{
@@ -12614,12 +12047,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aXB" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "aXD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12689,22 +12116,6 @@
 	},
 /turf/closed/wall,
 /area/hydroponics)
-"aXU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/library)
-"aXV" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/library)
-"aXW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "aXZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -12794,25 +12205,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aYq" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"aYr" = (
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "aYF" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
@@ -12939,9 +12331,6 @@
 "aYV" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"aYW" = (
-/turf/open/floor/carpet,
-/area/library)
 "aYX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12952,12 +12341,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aYY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "aYZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12976,23 +12359,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aZf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"aZd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
-/area/chapel/main)
-"aZg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/carpet,
-/area/chapel/main)
-"aZh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/chapel/main)
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "aZj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13308,13 +12681,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"bay" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "baz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -13339,25 +12705,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"baI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "baJ" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"baK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "baL" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
@@ -13374,17 +12727,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"baP" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"baQ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "baR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -13564,13 +12906,6 @@
 	dir = 1
 	},
 /area/hallway/primary/starboard)
-"bbC" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bbD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -13583,11 +12918,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/chapel/main)
-"bbM" = (
-/obj/item/book/manual/wiki/security_space_law,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bbN" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light,
@@ -13682,16 +13012,6 @@
 	},
 /obj/structure/table,
 /turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bbZ" = (
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine/longrange{
-	department = "Captain"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bca" = (
-/turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bcc" = (
 /obj/machinery/vending/snack/random,
@@ -13823,13 +13143,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bcN" = (
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine{
-	department = "Bridge"
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bcO" = (
 /obj/structure/sink{
 	dir = 8;
@@ -13837,18 +13150,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"bcP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bcQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "bcS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light/small{
@@ -13892,21 +13193,6 @@
 /obj/item/assembly/timer,
 /obj/structure/table,
 /turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bcZ" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Command)"
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
-"bda" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bdb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14011,12 +13297,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/vacant_room/commissary)
-"bdF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bdG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14027,19 +13307,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bdI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
-"bdK" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bdL" = (
 /obj/effect/landmark/blobstart,
 /obj/item/clothing/suit/ianshirt,
@@ -14081,15 +13348,6 @@
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
 /turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bdY" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bea" = (
 /obj/structure/disposalpipe/segment,
@@ -14701,11 +13959,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"bgz" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bgA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -14774,12 +14027,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"bgP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "bgQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -14823,10 +14070,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bha" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "bhb" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
@@ -15436,12 +14679,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bjn" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft,
-/obj/item/clothing/head/soft,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bjo" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
@@ -15555,24 +14792,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"bjS" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bjT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bjU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bjV" = (
@@ -16046,10 +15271,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"blL" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "blM" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/roboticist,
@@ -16153,23 +15374,6 @@
 "bmx" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/captain)
-"bmy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bmz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/dresser,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "bmC" = (
 /obj/structure/sink{
 	dir = 8;
@@ -16259,15 +15463,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bmM" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bmO" = (
@@ -16456,15 +15651,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bnH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bnI" = (
 /obj/machinery/computer/cargo/request,
 /turf/open/floor/plasteel,
@@ -16505,25 +15691,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
-"bnX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bnY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bnZ" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "boa" = (
 /obj/structure/toilet{
 	dir = 4
@@ -16564,29 +15731,6 @@
 "bog" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/medical/medbay/central)
-"boi" = (
-/obj/machinery/computer/med_data{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"boj" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/mob/living/simple_animal/bot/cleanbot{
-	name = "C.L.E.A.N."
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bol" = (
 /obj/machinery/airalarm{
@@ -16798,67 +15942,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
-"bpa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bpb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
-"bpd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
-"bpe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
 "bph" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bpj" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Captain's Quarters";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bpk" = (
-/obj/structure/closet/secure_closet/captains,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bpl" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/obj/item/razor{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/item/reagent_containers/food/drinks/flask/gold,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "bpm" = (
 /obj/machinery/shower{
 	dir = 1
@@ -16884,12 +15973,6 @@
 "bpw" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
-/area/medical/medbay/central)
-"bpy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -17014,6 +16097,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"bpZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bqa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -17120,10 +16209,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bqz" = (
-/obj/effect/mapping_helpers/iannewyear,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
 "bqA" = (
 /obj/machinery/computer/card{
 	dir = 1
@@ -17136,11 +16221,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/head_of_personnel)
-"bqB" = (
-/obj/machinery/holopad,
-/obj/effect/mapping_helpers/ianbirthday,
-/turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
 "bqF" = (
 /obj/machinery/power/apc{
@@ -17168,41 +16248,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/teleporter)
-"bqM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
-"bqN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bqP" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bqR" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17357,25 +16408,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"brV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
-"brX" = (
-/obj/structure/table,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "brY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -18319,29 +17351,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bwA" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bwB" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
-"bwC" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"bwD" = (
-/obj/machinery/sleeper,
-/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwE" = (
 /obj/structure/disposalpipe/segment,
@@ -18639,23 +17654,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/qm)
-"byn" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byt" = (
 /turf/closed/wall/r_wall,
@@ -19185,6 +18183,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"bAc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/holopad/emergency/medical,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "bAd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -19381,14 +18387,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bBb" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "bBc" = (
 /obj/structure/table,
 /obj/item/razor,
@@ -19424,29 +18422,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bBf" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Cargo";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
 "bBk" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/turf_decal/stripes/line{
@@ -19596,19 +18571,6 @@
 /area/medical/medbay/central)
 "bBN" = (
 /turf/closed/wall,
-/area/crew_quarters/heads/cmo)
-"bBO" = (
-/obj/machinery/computer/med_data,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bBQ" = (
 /obj/machinery/disposal/bin,
@@ -19877,12 +18839,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bCK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "bCL" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
@@ -19901,15 +18857,6 @@
 "bCN" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"bCO" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rxglasses,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCP" = (
@@ -20000,17 +18947,6 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bCY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
-"bCZ" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chief_medical_officer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -20247,47 +19183,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bEh" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
-"bEj" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
-"bEk" = (
-/obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/stamp/cmo,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "bEl" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
@@ -20340,10 +19235,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bEv" = (
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bEC" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -20576,18 +19467,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bFG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "bFI" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -20599,10 +19478,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bFK" = (
-/obj/structure/closet/wardrobe/pjs,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "bFL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -20635,21 +19510,6 @@
 /obj/item/cartridge/medical,
 /obj/item/cartridge/chemistry{
 	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
-"bFP" = (
-/obj/machinery/computer/card/minor/cmo{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21075,22 +19935,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bHY" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "bIb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white/side{
@@ -22818,29 +21662,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"bPz" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "bPA" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
@@ -24158,6 +22979,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bWU" = (
+/obj/machinery/camera{
+	c_tag = "Bridge Center";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bWV" = (
 /obj/structure/door_assembly/door_assembly_mai,
 /turf/open/floor/plating,
@@ -24346,6 +23184,16 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"bXM" = (
+/obj/machinery/computer/crew,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "bXO" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm{
@@ -24554,13 +23402,6 @@
 "bYH" = (
 /turf/closed/wall,
 /area/engine/break_room)
-"bYK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/checker,
-/area/engine/break_room)
 "bYL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -24607,15 +23448,6 @@
 /area/engine/atmos)
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bYY" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -24711,6 +23543,14 @@
 "bZy" = (
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"bZA" = (
+/obj/item/book/manual/wiki/security_space_law,
+/obj/structure/table/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "bZL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 8
@@ -24979,6 +23819,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"cbb" = (
+/obj/machinery/holopad/emergency/science,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "cbc" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -25021,23 +23865,6 @@
 	},
 /turf/closed/wall,
 /area/tcommsat/computer)
-"cbp" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "cbt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -25331,10 +24158,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cdl" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/chapel/main)
 "cdr" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -25397,13 +24220,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cdU" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/chief_engineer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cdV" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -25453,10 +24269,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"ceh" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/bridge)
 "cei" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -25465,12 +24277,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"ceo" = (
-/obj/machinery/keycard_auth{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cer" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25530,6 +24336,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"ceU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ceV" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -25900,19 +24710,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"cim" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
-"cio" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/paper/monitorkey,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cit" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -26107,28 +24904,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"cjY" = (
-/obj/structure/table/reinforced,
-/obj/item/cartridge/engineering{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 3
-	},
-/obj/item/cartridge/atmos,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "ckb" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/structure/grille,
@@ -26209,6 +24984,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ckI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/crowbar,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "ckQ" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
@@ -26617,11 +25405,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"cnv" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
@@ -26768,10 +25551,6 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solar/starboard/aft)
-"cpq" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cps" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -27112,6 +25891,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cuS" = (
+/obj/machinery/camera{
+	c_tag = "Bridge East";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "cva" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -27738,13 +26530,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cBM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/rcl/pre_loaded,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cBO" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -27786,6 +26571,16 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"cCg" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/dresser,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "cCh" = (
 /obj/item/bedsheet/red,
 /mob/living/simple_animal/bot/secbot/beepsky{
@@ -27857,6 +26652,21 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"cDa" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
+"cDk" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "cDz" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -28013,6 +26823,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"cGR" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
+	},
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cHu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28084,10 +26903,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"cHT" = (
-/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHU" = (
@@ -28457,15 +27272,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"cPs" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "cPv" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28494,6 +27300,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"cPz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/green,
+/area/quartermaster/qm)
 "cPI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -28530,19 +27342,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"cRo" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Logistics Station"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "cRx" = (
 /obj/item/kirbyplants,
 /turf/open/floor/circuit,
@@ -28626,13 +27425,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"cSZ" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
+"cTd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "cTf" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -28646,6 +27442,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cTx" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "cTE" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -28678,10 +27480,38 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cUd" = (
+/obj/structure/table/reinforced,
+/obj/item/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 3
+	},
+/obj/item/cartridge/atmos,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "cUk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"cUv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "cUx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28704,6 +27534,17 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cVc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/checker,
+/area/engine/break_room)
 "cVT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28940,6 +27781,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"deV" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "dfj" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light{
@@ -29102,6 +27948,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"dkH" = (
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "dkN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -29278,6 +28127,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"doF" = (
+/obj/machinery/computer/station_alert,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "doL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white/side{
@@ -29299,6 +28156,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dqq" = (
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "dqu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -29605,6 +28468,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"dAn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "dAI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29681,18 +28551,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"dCy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+"dBP" = (
+/obj/structure/table,
+/obj/item/clothing/head/soft,
+/obj/item/clothing/head/soft,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/qm)
+/area/quartermaster/storage)
 "dCJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -29731,16 +28599,6 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/white/side,
 /area/science/explab)
-"dEv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "dEM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29839,6 +28697,9 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"dIG" = (
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "dIJ" = (
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -29849,6 +28710,13 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"dJz" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "dJG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29914,19 +28782,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"dMP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "dNl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -29979,6 +28834,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"dNM" = (
+/obj/structure/light_construct/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "dOe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -30323,6 +29184,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness)
+"eal" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eau" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -30336,13 +29208,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"ecB" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ecL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30530,6 +29395,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ejg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "eke" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable{
@@ -30540,6 +29418,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"emj" = (
+/obj/machinery/computer/atmos_alert,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "emD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30595,6 +29484,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"enm" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "enu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30692,6 +29593,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"eqg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "eqh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30744,13 +29652,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"erN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "erW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -30791,6 +29692,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"esP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "esS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -30816,6 +29729,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"euj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "euD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30833,15 +29753,15 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
-"evj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"euY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/holopad/emergency/bar,
 /turf/open/floor/plasteel,
-/area/bridge)
+/area/crew_quarters/bar)
 "ewM" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -30852,6 +29772,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"ewV" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "ewW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -30943,6 +29873,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"ezd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ezf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31083,6 +30026,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eEO" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/machinery/camera{
+	c_tag = "Security Post - Cargo";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/computer/security/mining{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "eGf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -31190,18 +30156,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"eKm" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "eKG" = (
 /obj/machinery/light{
 	dir = 1
@@ -31237,6 +30191,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eMo" = (
+/obj/machinery/computer/card/minor/cmo{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "eMr" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -31344,6 +30316,26 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"eRK" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
+"eSc" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/bridge";
+	name = "Bridge APC";
+	pixel_y = -24
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "eSR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -31419,6 +30411,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eUI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "eUV" = (
 /obj/machinery/door/window/southleft{
 	name = "SMES Chamber";
@@ -31554,6 +30553,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"fbk" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "fbD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses,
@@ -31689,23 +30696,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ffT" = (
-/obj/effect/landmark/xeno_spawn,
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
-"fga" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "fgE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31961,6 +30951,15 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"fpo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fpD" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -32077,6 +31076,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"fsK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fsY" = (
 /obj/machinery/light{
 	dir = 4
@@ -32166,6 +31180,13 @@
 /obj/item/aiModule/supplied/protectStation,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"fvU" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "fvY" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -32192,20 +31213,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"fwG" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "fxa" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -32289,6 +31296,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fyQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fzb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32341,21 +31358,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"fBS" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "fCp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -32490,6 +31492,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fHI" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"fIb" = (
+/obj/structure/chair{
+	dir = 1;
+	name = "Logistics Station"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fII" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -32576,6 +31602,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"fLm" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "fLp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -32635,6 +31667,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fPh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "fPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -32644,6 +31683,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"fPC" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "fPK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32712,6 +31760,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"fRA" = (
+/obj/machinery/computer/security/mining,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fRC" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -32761,6 +31820,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fSJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fTK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32785,6 +31855,20 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"fVB" = (
+/obj/structure/chair{
+	dir = 1;
+	name = "Security Station"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/lieutenant,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fWF" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory North"
@@ -33062,6 +32146,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ghi" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rxglasses,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "ghv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -33154,6 +32251,37 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"gjw" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light_switch{
+	dir = 6;
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
+"gjS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "gkh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33305,6 +32433,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gnA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "goa" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -33400,6 +32535,15 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/lawoffice)
+"gpH" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/cyan,
+/area/crew_quarters/heads/cmo)
 "gpV" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -33474,6 +32618,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gsW" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "gtk" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -33734,21 +32889,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"gBd" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "gBm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -33984,6 +33124,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gLp" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/green,
+/area/library)
 "gMb" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -34188,6 +33332,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gTi" = (
+/obj/machinery/camera{
+	c_tag = "Security Post - Science";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "gTt" = (
 /obj/item/wrench,
 /obj/item/wrench,
@@ -34203,6 +33369,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"gTv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "gUw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34235,10 +33413,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"gWr" = (
-/obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "gXa" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -34277,6 +33451,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gXX" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/paper/monitorkey,
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "gYB" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm6";
@@ -34346,6 +33530,14 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"gZQ" = (
+/obj/structure/closet/secure_closet/captains,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "gZY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -34446,6 +33638,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"hdc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "hdl" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34487,6 +33691,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hez" = (
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 8;
+	name = "Medbay RC";
+	pixel_x = -32
+	},
+/obj/machinery/computer/med_data{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "heP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -34519,25 +33736,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hfD" = (
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "hfE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hfP" = (
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "hgA" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/fore)
-"hgM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
 "hhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34586,6 +33810,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hiO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/library)
 "hjt" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -34636,6 +33866,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"hjK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "hjM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35004,6 +34240,12 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/department/crew_quarters/bar)
+"huZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "hvl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -35130,6 +34372,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hyw" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "hyU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -35355,6 +34609,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hIr" = (
+/obj/structure/chair{
+	dir = 1;
+	name = "Command Station"
+	},
+/obj/machinery/button/door{
+	id = "bridge blast";
+	name = "Bridge Blast Door Control";
+	pixel_x = 28;
+	pixel_y = -2;
+	req_access_txt = "19"
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 29;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"hJB" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "hKf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35404,6 +34681,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"hLs" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad/emergency/engineering,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hNp" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -35422,6 +34704,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"hNL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "hOa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -35442,6 +34732,15 @@
 /obj/machinery/computer/atmos_control,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hPo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hQe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -35573,6 +34872,21 @@
 "hTU" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"hUd" = (
+/obj/machinery/camera{
+	c_tag = "Head of Security's Office";
+	dir = 4
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "hUs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -35582,6 +34896,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hUG" = (
+/obj/machinery/computer/med_data,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "hUN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36128,6 +35453,19 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"itt" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "itD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/wood,
@@ -36153,12 +35491,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"itZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"itH" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Command)"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "iuN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -36169,6 +35510,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ivB" = (
+/obj/structure/chair{
+	dir = 1;
+	name = "Engineering Station"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ivW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -36221,6 +35569,23 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"iyZ" = (
+/obj/machinery/computer/monitor{
+	name = "bridge power monitoring console"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "izr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -36321,18 +35686,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"iDt" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "iFn" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -36401,6 +35754,17 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/department/crew_quarters/bar)
+"iGy" = (
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/landmark/start/lieutenant,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "iGX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -36447,6 +35811,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"iHR" = (
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "iHT" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -36475,6 +35850,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iKn" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "iKt" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
@@ -36521,6 +35902,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"iLQ" = (
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/lootdrop/gambling,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "iMP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/chemist,
@@ -36586,13 +35972,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"iPr" = (
-/obj/machinery/photocopier,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
 "iPR" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -36618,6 +35997,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iRs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "iRE" = (
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab";
@@ -36666,6 +36054,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"iTF" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Treatment Center";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/stasis,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "iTJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -36751,6 +36148,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iZf" = (
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall,
+/area/medical/pharmacy)
+"iZu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iZC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AIW";
@@ -36827,6 +36249,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"jaR" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "jbg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -36884,6 +36310,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"jdf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/library)
 "jdD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -37074,6 +36509,14 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"jiD" = (
+/obj/structure/table/glass,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "jiK" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow,
@@ -37123,6 +36566,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"jkc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "jkA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37161,19 +36612,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/break_room)
-"jml" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "jmD" = (
 /obj/structure/grille/broken,
 /obj/structure/window{
@@ -37281,6 +36719,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jpy" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/carpet/cyan,
+/area/crew_quarters/heads/cmo)
 "jqQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37311,6 +36754,10 @@
 	dir = 9
 	},
 /area/science/research)
+"jrV" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "jsd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -37329,6 +36776,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"jsn" = (
+/turf/open/floor/carpet/green,
+/area/library)
 "jsP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -37477,6 +36927,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jyI" = (
+/obj/machinery/computer/crew,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37525,6 +36983,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jAF" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 24;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "jAK" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -37580,17 +37049,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jCO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+"jCJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "jDN" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -37611,18 +37075,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jEk" = (
-/obj/structure/table/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "jEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -37728,18 +37180,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"jJl" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "jJM" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/toxins{
@@ -37863,6 +37303,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"jMs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/lieutenant,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jMt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38231,6 +37682,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"jXM" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jYe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -38336,6 +37793,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"kcI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/library)
 "kdc" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -38377,6 +37840,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"keQ" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "keW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sorting/mail{
@@ -38473,6 +37940,17 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"kka" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/razor{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/reagent_containers/food/drinks/flask/gold,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "kkn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -38654,34 +38132,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kpS" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "kqg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38734,6 +38184,19 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"ksx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ktd" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -38826,6 +38289,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kxr" = (
+/obj/structure/chair{
+	dir = 1;
+	name = "Crew Station"
+	},
+/obj/effect/landmark/start/lieutenant,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"kxz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "kxF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -38841,6 +38318,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
+"kxU" = (
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Captain"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "kyi" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -38858,6 +38342,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"kyt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "kyS" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
@@ -39036,6 +38537,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"kFL" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "kFY" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -39316,6 +38827,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"kPN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "kPS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39431,6 +38948,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"kTY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "kUl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -39628,6 +39160,10 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"lbb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "lbg" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39936,6 +39472,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"liG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lji" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -39967,6 +39507,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ljE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ljH" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -40069,6 +39616,14 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lmH" = (
+/obj/machinery/computer/atmos_alert,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40100,6 +39655,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lnY" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lot" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/stripes/line{
@@ -40113,6 +39682,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"lpO" = (
+/obj/effect/mapping_helpers/ianbirthday,
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "lqq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40153,21 +39727,15 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
-"ltk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/cargo/request{
-	dir = 4
+"ltQ" = (
+/obj/machinery/computer/cargo/request,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	dir = 8;
-	name = "Medbay RC";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"ltD" = (
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"luK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40181,7 +39749,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "lvs" = (
 /obj/structure/disposalpipe/segment{
@@ -40246,6 +39814,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
+"lyF" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"lze" = (
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lzH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40320,6 +39909,13 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"lCk" = (
+/obj/item/storage/secure/safe/HoS{
+	pixel_x = 35
+	},
+/obj/structure/closet/secure_closet/hos,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "lCT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40332,6 +39928,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"lDy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lDW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40341,6 +39943,22 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"lEe" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lEi" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/scanning_module,
@@ -40373,6 +39991,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"lEs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "lEO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -40523,11 +40147,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"lJM" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/lootdrop/gambling,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
+"lKy" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lKZ" = (
 /obj/item/radio/intercom{
 	pixel_y = 20
@@ -40546,6 +40175,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"lLj" = (
+/obj/machinery/suit_storage_unit/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	dir = 8;
+	name = "Chief Medical Officer RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "lLp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -40641,6 +40288,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lPe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lPp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40986,14 +40639,6 @@
 	dir = 5
 	},
 /area/science/research)
-"lZH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "lZN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -41149,6 +40794,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"meR" = (
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "mfj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41263,33 +40917,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mgJ" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -31
-	},
-/obj/structure/table/wood,
-/obj/item/storage/box/seccarts{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/storage/box/deputy,
-/obj/machinery/button/door{
-	id = "hosspace";
-	name = "Space Shutters Control";
-	pixel_x = -26;
-	pixel_y = 34
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	dir = 1;
-	name = "Head of Security RC";
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "mgP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41369,13 +40996,24 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"miF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	icon_state = "1-2"
+"mim" = (
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
+"miY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/library)
+"miZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mjr" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -41409,10 +41047,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"mll" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mlQ" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/rd,
@@ -41513,24 +41147,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"mpK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/library)
 "mpN" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
@@ -41547,6 +41163,44 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"mqO" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"mqT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/science/nanite)
 "mrd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -41586,17 +41240,6 @@
 	dir = 8
 	},
 /area/science/explab)
-"msI" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "msL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41632,29 +41275,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"muN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
-"muW" = (
-/obj/item/book/manual/wiki/security_space_law,
-/obj/structure/table/wood,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "mvb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41827,6 +41447,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"mzK" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "mBI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41942,6 +41575,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"mDQ" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "mDS" = (
 /obj/structure/table,
 /obj/item/phone{
@@ -42000,6 +41637,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"mFm" = (
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/stamp/cmo,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/carpet/cyan,
+/area/crew_quarters/heads/cmo)
 "mFq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -42050,6 +41694,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness)
+"mGK" = (
+/obj/effect/mapping_helpers/iannewyear,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "mGQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
@@ -42217,6 +41865,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mKG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/library)
+"mLa" = (
+/obj/machinery/sleeper{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "mLh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -42298,20 +41961,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mNs" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "mNx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -42371,6 +42020,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mOr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mOC" = (
 /obj/machinery/camera{
 	c_tag = "Engineering SMES";
@@ -42426,6 +42089,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"mQV" = (
+/obj/effect/landmark/xeno_spawn,
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "mRc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/break_room";
@@ -42820,32 +42488,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"nbK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	dir = 8;
-	name = "Engineering Security APC";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/newscaster{
-	dir = 1;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "nbP" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -42972,6 +42614,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"nex" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 8;
+	name = "Science Requests Console";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "neJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -43078,6 +42737,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nir" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nju" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -43236,6 +42903,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nmZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "nnb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43279,6 +42952,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"npt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "nqP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -43306,15 +42992,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"nrj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"nre" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "nro" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -43361,17 +43045,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nrV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/lieutenant,
-/turf/open/floor/plasteel,
-/area/bridge)
 "nrX" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -43401,6 +43074,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/maintenance/solars/port/aft)
+"ntd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "ntl" = (
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/structure/sign/poster/official/safety_eye_protection{
@@ -43480,6 +43160,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nwk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "nwT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -43732,6 +43419,21 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"nCv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "nCH" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
@@ -43935,6 +43637,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"nIm" = (
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "nJc" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/navbeacon{
@@ -44000,6 +43705,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"nMc" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "nMn" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -44044,6 +43764,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"nNp" = (
+/mob/living/simple_animal/hostile/retaliate/bat{
+	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
+	emote_hear = list("chitters");
+	faction = list("spiders");
+	harm_intent_damage = 3;
+	health = 200;
+	icon_dead = "guard_dead";
+	icon_gib = "guard_dead";
+	icon_living = "guard";
+	icon_state = "guard";
+	maxHealth = 250;
+	max_co2 = 5;
+	max_tox = 2;
+	melee_damage_lower = 15;
+	melee_damage_upper = 20;
+	min_oxy = 5;
+	movement_type = 1;
+	name = "Sergeant Araneus";
+	real_name = "Sergeant Araneus";
+	response_help_continuous = "pets";
+	response_help_simple = "pet";
+	turns_per_move = 10
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "nNK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -44067,12 +43813,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
-"nOu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
 "nOy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -44082,15 +43822,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"nOM" = (
-/obj/effect/turf_decal/tile/blue{
+"nOU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "nPc" = (
 /obj/structure/table,
 /obj/item/rcl/pre_loaded,
@@ -44205,15 +43955,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"nUe" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "nUj" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -44296,6 +44037,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"nZB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "nZT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44523,6 +44270,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ogK" = (
+/obj/structure/table,
+/obj/item/disk/design_disk,
+/obj/item/disk/design_disk,
+/obj/item/disk/tech_disk,
+/obj/item/disk/tech_disk,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "ogS" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -44666,14 +44424,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"okd" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "okH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
@@ -44716,53 +44466,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"omQ" = (
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "omW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
 /area/maintenance/department/electrical)
-"onj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "onk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -44900,6 +44609,27 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"orY" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"osa" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "osD" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light_switch{
@@ -45039,6 +44769,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
+"oxr" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
+	dir = 8;
+	name = "Engineering Security APC";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "oxC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45133,6 +44889,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"oBl" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "oBu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -45283,14 +45043,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"oHp" = (
-/obj/structure/table,
-/obj/item/disk/design_disk,
-/obj/item/disk/design_disk,
-/obj/item/disk/tech_disk,
-/obj/item/disk/tech_disk,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "oHw" = (
 /obj/machinery/light{
 	dir = 4
@@ -45412,24 +45164,6 @@
 	},
 /turf/open/space,
 /area/science/mixing)
-"oLs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "oLG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -45606,6 +45340,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oQx" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "oQF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45678,6 +45418,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"oTh" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "oTq" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -45898,23 +45644,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"pfg" = (
-/obj/machinery/camera{
-	c_tag = "Bridge Center";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "pfm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
@@ -45972,6 +45701,24 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"phk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "pho" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -46001,11 +45748,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"phK" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
+"phH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "pil" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -46039,6 +45787,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"piw" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "piA" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -46088,6 +45842,29 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"pky" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "plp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46250,6 +46027,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"pqw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "pqB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46446,15 +46229,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"puT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/nanite)
 "puY" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -46527,6 +46301,26 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"pxs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "pya" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46900,6 +46694,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pJU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/green,
+/area/crew_quarters/bar)
 "pKy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47079,6 +46878,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pPJ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "pQh" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -47125,6 +46935,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"pRS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "pRW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -47230,6 +47046,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"pWD" = (
+/obj/structure/closet/toolcloset,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pWH" = (
 /obj/item/wrench,
 /obj/effect/turf_decal/stripes/line,
@@ -47319,6 +47143,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"pZO" = (
+/obj/item/book/manual/wiki/security_space_law,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "qae" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/flip{
@@ -47461,19 +47290,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qeB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "qfd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -47510,15 +47326,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"qhN" = (
+/obj/structure/closet/wardrobe/pjs,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "qhX" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/explab)
-"qid" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
+"qhZ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/carpet/cyan,
+/area/crew_quarters/heads/cmo)
 "qje" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47534,17 +47359,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qjl" = (
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/landmark/start/lieutenant,
-/turf/open/floor/plasteel,
-/area/bridge)
 "qjx" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -47642,22 +47456,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"qmI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "qmP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -47760,12 +47558,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"qpl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "qpS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -47824,6 +47616,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"qrh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "qrs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -47860,10 +47658,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "qsw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "qsD" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -47945,6 +47748,12 @@
 	dir = 5
 	},
 /area/science/research)
+"qts" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "quy" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -48155,17 +47964,16 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"qBH" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+"qBR" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "qBW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -48173,6 +47981,27 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"qBZ" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "qDa" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
@@ -48232,6 +48061,21 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"qFp" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qFS" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Reception";
@@ -48330,6 +48174,29 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"qLo" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/item/wrench,
+/obj/item/assembly/timer,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"qLF" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "qLP" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -48346,6 +48213,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"qMZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "qNs" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/tile/neutral{
@@ -48363,16 +48243,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"qNv" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "qNw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -48503,6 +48373,14 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"qQW" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/holopad/emergency/bar,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "qQX" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AftH";
@@ -48548,6 +48426,15 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"qSy" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "qTh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -48610,17 +48497,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"qWs" = (
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	dir = 8;
-	name = "Science Requests Console";
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "qWA" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -48715,6 +48591,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"qZc" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -31
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/seccarts{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/box/deputy,
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = -26;
+	pixel_y = 34
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Head of Security RC";
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "qZf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48825,6 +48728,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"rdv" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/green,
+/area/crew_quarters/bar)
 "rdL" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -48842,37 +48751,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rdT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
-	dir = 8;
-	name = "Head of Security's Office APC";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"reu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "rew" = (
 /obj/machinery/button/door{
 	id = "maint2";
@@ -48949,6 +48827,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"rgE" = (
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer"
+	},
+/turf/open/floor/carpet/cyan,
+/area/crew_quarters/heads/cmo)
 "rgK" = (
 /obj/machinery/button/door{
 	id = "stationawaygate";
@@ -49045,16 +48930,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"rky" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "rlu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
@@ -49154,6 +49029,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rpG" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "rpN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49279,25 +49163,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
-"rss" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/department/crew_quarters/bar)
-"rst" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "rsv" = (
 /obj/machinery/light{
 	dir = 4
@@ -49545,32 +49410,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rBA" = (
-/mob/living/simple_animal/hostile/retaliate/bat{
-	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
-	emote_hear = list("chitters");
-	faction = list("spiders");
-	harm_intent_damage = 3;
-	health = 200;
-	icon_dead = "guard_dead";
-	icon_gib = "guard_dead";
-	icon_living = "guard";
-	icon_state = "guard";
-	maxHealth = 250;
-	max_co2 = 5;
-	max_tox = 2;
-	melee_damage_lower = 15;
-	melee_damage_upper = 20;
-	min_oxy = 5;
-	movement_type = 1;
-	name = "Sergeant Araneus";
-	real_name = "Sergeant Araneus";
-	response_help_continuous = "pets";
-	response_help_simple = "pet";
-	turns_per_move = 10
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "rBE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -49581,6 +49420,19 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"rBI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "rBL" = (
 /obj/machinery/door/window/westleft{
 	name = "Delivery Desk";
@@ -49688,6 +49540,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"rGy" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"rGL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/library)
 "rHy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49758,6 +49630,19 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"rLH" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/med_data,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "rLQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49801,20 +49686,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"rNM" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Security Station"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start/lieutenant,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "rNR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -49960,6 +49831,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"rVi" = (
+/obj/machinery/keycard_auth{
+	pixel_y = -28
+	},
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "rVr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/main";
@@ -50046,6 +49923,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rXX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"rYv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "rYE" = (
 /obj/machinery/light{
 	dir = 1
@@ -50062,13 +49951,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rYW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "rZb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50154,6 +50036,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"scF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "sdK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50324,6 +50217,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"sih" = (
+/obj/machinery/computer/shuttle/labor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "sin" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -50345,6 +50249,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"siD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/hos,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "siM" = (
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom{
@@ -50528,19 +50439,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"spP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"spU" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
+"sqe" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hos";
+	dir = 8;
+	name = "Head of Security's Office APC";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "sqn" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -50569,6 +50495,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"srp" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "srH" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
@@ -50604,6 +50538,19 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
+"ssY" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Captain's Quarters";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "stb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -50677,20 +50624,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"svZ" = (
-/obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+"svq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "swh" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/aft";
@@ -50741,6 +50685,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"sxn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "sxr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -50933,16 +50884,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sDt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "sDw" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51013,22 +50954,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"sGL" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "sHl" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -51036,6 +50961,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"sHX" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light,
+/mob/living/simple_animal/bot/cleanbot{
+	name = "C.L.E.A.N."
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "sIc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51187,11 +51126,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sND" = (
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "sNJ" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"sNL" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/quartermaster,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/green,
+/area/quartermaster/qm)
 "sNY" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -51302,20 +51252,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"sQH" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "sRg" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -51362,6 +51298,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"sSb" = (
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/medical)
 "sSP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -51382,6 +51333,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"sUe" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "sUL" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -51420,6 +51397,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"sVJ" = (
+/obj/machinery/camera{
+	c_tag = "Bridge West";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "sVM" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51933,6 +51923,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"tlq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/storage/box/masks,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "tlF" = (
 /obj/structure/table,
 /obj/item/aiModule/supplied/quarantine,
@@ -52006,21 +52008,6 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"toc" = (
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
 "tox" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
@@ -52130,6 +52117,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"trG" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "tsk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line,
@@ -52140,6 +52143,13 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"tsI" = (
+/obj/machinery/photocopier,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/head_of_personnel)
 "tsY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52315,6 +52325,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"tyT" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "tyV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -52525,6 +52539,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tFq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tFy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52562,36 +52584,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tGd" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/library)
-"tGX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "tGZ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -52609,18 +52601,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"tIN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "tIO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52684,6 +52664,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"tLn" = (
+/obj/machinery/computer/card/minor/hos,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "tLy" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -52704,6 +52688,13 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"tMQ" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "tNu" = (
 /obj/machinery/light{
 	dir = 1
@@ -52820,6 +52811,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tSW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/library)
 "tTN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52912,16 +52921,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"tYO" = (
-/obj/item/beacon,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "tZd" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry - Factory Mid"
@@ -53271,6 +53270,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"ukn" = (
+/obj/machinery/holopad/emergency/medical,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"ukY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "ulh" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -53553,13 +53566,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"utl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
 "utq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -53622,19 +53628,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uvt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "uvv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/cable{
@@ -53751,16 +53744,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uAo" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+"uAf" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "uAp" = (
 /obj/machinery/suit_storage_unit/cmo{
@@ -53797,6 +53784,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uCe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"uCi" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uDl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -53816,6 +53832,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uDE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/primary/central)
 "uDI" = (
 /obj/structure/table,
 /obj/item/assembly/igniter{
@@ -53836,16 +53857,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"uDN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "uDP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"uEp" = (
+/obj/structure/closet/bombcloset/security,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "uEs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -53949,6 +53972,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uIP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uIZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -53967,6 +53999,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"uJE" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "uJL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -54031,6 +54071,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"uLc" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "uLi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -54284,6 +54331,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"uQJ" = (
+/obj/machinery/computer/prisoner/management,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uQM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54319,6 +54377,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"uSR" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/green,
+/area/maintenance/department/crew_quarters/bar)
 "uSY" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/fore";
@@ -54475,32 +54542,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"uWN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "uWX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -54547,6 +54588,32 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"uYH" = (
+/obj/machinery/camera{
+	c_tag = "Brig Infirmary";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/brig_phys,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
+"uZs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/heads/captain)
 "uZu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/meter,
@@ -54710,14 +54777,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"veB" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/quartermaster,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "vfd" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -54901,6 +54960,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vmJ" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vmZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
@@ -55064,18 +55135,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vrm" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "vrq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -55181,6 +55240,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"vwu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vwL" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -55322,12 +55393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vAg" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
 "vAh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -55393,6 +55458,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vCJ" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vCK" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -55428,12 +55519,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"vEw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"vEY" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "vFa" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
@@ -55558,6 +55655,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vJs" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/stamp/hos,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "vKb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55625,21 +55728,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"vLX" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "vMD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55694,6 +55782,10 @@
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
+"vNV" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vNX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55701,6 +55793,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"vOU" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "vPn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -55732,6 +55835,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vQD" = (
+/obj/machinery/camera{
+	c_tag = "Brig Control Room";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "vQE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/sign/warning/securearea,
@@ -55765,11 +55898,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"vRe" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "vRl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55786,6 +55914,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vRR" = (
+/obj/machinery/computer/security/hos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "vRW" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -55908,6 +56043,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vVe" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "vVM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56002,16 +56141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vYo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "vYy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56181,11 +56310,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wcZ" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
 "wdq" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay"
@@ -56331,6 +56455,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"wgY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/library)
 "whu" = (
 /obj/machinery/light{
 	dir = 1
@@ -56361,6 +56500,17 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/engine/atmos)
+"whE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "whK" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -56431,6 +56581,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"wme" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head of Security";
+	req_access_txt = "58"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "wnf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56460,6 +56625,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wnz" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "wnD" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
@@ -56492,10 +56667,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"won" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "wop" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -56537,6 +56708,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"wpC" = (
+/obj/machinery/computer/shuttle/mining,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "wqG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -56599,6 +56784,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"wrV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "wrZ" = (
 /obj/machinery/bluespace_beacon,
 /obj/structure/cable{
@@ -56606,6 +56803,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"wtn" = (
+/obj/machinery/computer/communications,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "wud" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56693,6 +56898,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"wzu" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "wzB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -56743,21 +56963,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wzV" = (
-/obj/machinery/camera{
-	c_tag = "Head of Security's Office";
-	dir = 4
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/newscaster/security_unit{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "wAs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56924,21 +57129,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wDo" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "wDR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/nanite_chamber,
@@ -56960,6 +57150,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wEC" = (
+/obj/machinery/holopad/emergency/science,
+/turf/open/floor/plasteel/white,
+/area/science/lab)
+"wFd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "wFK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -57216,19 +57416,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"wMR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "wNk" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
@@ -57434,14 +57621,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"wTP" = (
-/obj/effect/turf_decal/tile/yellow{
+"wTH" = (
+/obj/item/beacon,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "wUs" = (
 /obj/structure/closet/secure_closet/detective,
@@ -57505,6 +57693,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
+"wXa" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "wZe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -57539,6 +57734,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"xac" = (
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine{
+	department = "Bridge"
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "xal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -57546,18 +57748,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"xaC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "xaL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57570,28 +57760,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xbe" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Science";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "xbm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -57604,6 +57772,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"xbr" = (
+/obj/structure/table/reinforced,
+/obj/item/aicard,
+/obj/item/multitool,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xbt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -57630,6 +57810,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"xcs" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "xcu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57677,6 +57872,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xdM" = (
+/turf/open/floor/carpet/green,
+/area/chapel/main)
 "xez" = (
 /obj/machinery/light{
 	dir = 4
@@ -57777,13 +57975,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"xgS" = (
-/obj/machinery/computer/security/hos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "xgT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/power/apc{
@@ -57807,12 +57998,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"xiq" = (
-/obj/structure/light_construct/small{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
 "xiD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only,
@@ -57879,6 +58064,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"xkZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"xlh" = (
+/obj/machinery/holopad,
+/turf/open/floor/carpet/green,
+/area/library)
 "xlO" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -57989,10 +58187,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"xpp" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
 "xqn" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -58029,23 +58223,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xqY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "xry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58104,23 +58281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"xsM" = (
-/obj/machinery/computer/monitor{
-	name = "bridge power monitoring console"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "xsT" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
@@ -58276,6 +58436,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xyp" = (
+/obj/machinery/holopad/emergency/science,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xyt" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58338,6 +58502,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
+"xAx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xBf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58624,20 +58793,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xIW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "xJl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -58670,6 +58825,17 @@
 /obj/machinery/nanite_programmer,
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"xJP" = (
+/obj/machinery/modular_computer/console/preset/command,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xJQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -58718,6 +58884,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"xLC" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xMd" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -58779,6 +58951,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xOP" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/obj/item/storage/box/PDAs{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/ids,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xOQ" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -58939,6 +59121,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"xXh" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "xXK" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -59185,6 +59374,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"ygu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/green,
+/area/quartermaster/qm)
 "ygI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -73863,7 +74064,7 @@ alU
 pfI
 sbM
 aCZ
-aEJ
+vOU
 aFL
 aBI
 aIO
@@ -78769,7 +78970,7 @@ bcw
 bfd
 oZb
 aZE
-bjn
+dBP
 bjr
 bkt
 gwb
@@ -80066,7 +80267,7 @@ bjr
 bjr
 kLh
 byz
-vEw
+cPz
 byc
 hNp
 aaa
@@ -80323,7 +80524,7 @@ brN
 brN
 bxx
 byC
-veB
+sNL
 byl
 hNp
 aaf
@@ -80580,7 +80781,7 @@ buD
 bvY
 bxx
 byB
-dCy
+ygu
 byg
 hNp
 aaa
@@ -80838,7 +81039,7 @@ aZE
 bxu
 byD
 xRG
-byn
+gjw
 bxu
 aaa
 bxy
@@ -81116,9 +81317,9 @@ bVG
 bHE
 bHE
 bCq
-phK
-xiq
-qid
+deV
+dNM
+jrV
 awX
 ylY
 gpV
@@ -81339,7 +81540,7 @@ aPz
 bdW
 aSg
 aZE
-bgz
+qSy
 biT
 boU
 dks
@@ -81373,9 +81574,9 @@ bCq
 bCq
 bCq
 bRz
-wcZ
-ffT
-rss
+eRK
+mQV
+dIG
 utd
 icl
 icl
@@ -81629,10 +81830,10 @@ bHE
 bCq
 fet
 fet
-fet
-fet
-fet
-fet
+dIG
+dIG
+dIG
+dIG
 awX
 hRQ
 gpV
@@ -82385,7 +82586,7 @@ bwe
 tzX
 bBI
 bGn
-bGn
+uJE
 bGn
 bKq
 bxy
@@ -82398,14 +82599,14 @@ bCq
 bCq
 muB
 bCq
-hgM
+uSR
 ktL
 fet
 huW
 gtk
 fet
 fet
-xpp
+jaR
 fet
 fet
 bLv
@@ -82655,15 +82856,15 @@ aaa
 tUv
 eiO
 olD
-vAg
-vRe
+piw
+dIG
 jbL
 qAk
 qAk
 iFS
-xpp
-lJM
-xpp
+jaR
+iLQ
+jaR
 fet
 bLv
 uAD
@@ -82912,14 +83113,14 @@ aaf
 tUv
 vkx
 bCq
-fet
+dIG
 fet
 rih
 qAk
 qAk
 sBx
 fet
-xpp
+jaR
 fet
 fet
 bLv
@@ -83408,7 +83609,7 @@ pqP
 bwd
 byM
 bAd
-bBf
+eEO
 bwe
 plp
 bCe
@@ -83962,7 +84163,7 @@ ydz
 oip
 uTF
 tDz
-cpq
+pWD
 dfj
 cgR
 crp
@@ -84903,7 +85104,7 @@ aov
 ihe
 ata
 arR
-ata
+hfP
 aph
 aph
 aph
@@ -84941,7 +85142,7 @@ bjB
 jTf
 bmp
 bjz
-bpa
+tFq
 bqy
 cBr
 bqy
@@ -85441,14 +85642,14 @@ aaa
 aaa
 aTQ
 qBW
-uWN
+sUe
 aVd
 aZM
 fen
-baI
-bda
-bda
-bca
+nZB
+cTx
+cTx
+nIm
 bgJ
 aZP
 sRB
@@ -85697,24 +85898,24 @@ jOW
 aaa
 aaa
 aPR
-sQH
-fwG
-msI
+rGy
+uCi
+pPJ
 aZM
 aZy
-bay
-bcZ
-bdY
-bdF
+xXh
+itH
+meR
+qrh
 bgI
 aZP
 bjC
 hnQ
 bmo
 wiv
-bpb
-bqz
-nOu
+kxz
+mGK
+qts
 brS
 bsY
 bue
@@ -85916,7 +86117,7 @@ afH
 agj
 agM
 hXI
-ahW
+uYH
 aiD
 agj
 wPI
@@ -85955,23 +86156,23 @@ aaa
 aPR
 aPR
 aPR
-wMR
+qMZ
 aPR
 aZM
 bbX
-bay
-bbM
-bcN
-bdK
+xXh
+pZO
+xac
+dJz
 bgL
 aZP
 aZP
 aZP
 bmo
 bnR
-bpe
-bqB
-iPr
+anh
+lpO
+tsI
 btD
 buO
 bwk
@@ -86210,25 +86411,25 @@ aOE
 jOW
 aaa
 aPR
-aTR
-aVe
-erN
-aYq
+uQJ
+sVJ
+eUI
+orY
 aZO
 wCj
-baK
-bbC
-bbC
-bdI
+euj
+fvU
+fvU
+huZ
 bgK
 bgK
 bjE
 bgK
 bmq
 bnQ
-bpd
-bpd
-utl
+lbb
+lbb
+sxn
 btC
 buN
 bwj
@@ -86467,10 +86668,10 @@ aOE
 jOW
 aaa
 aPR
-aTT
-rNM
-onj
-jCO
+srp
+fVB
+uCe
+qsw
 xoZ
 lqx
 krL
@@ -86724,10 +86925,10 @@ lgi
 aPR
 aPR
 aPR
-aTS
-xaC
-aWM
-aYr
+fHI
+gTv
+lPe
+hfD
 aZP
 bbh
 bcc
@@ -86979,12 +87180,12 @@ gVl
 edR
 aOE
 lXn
-aRj
-aSv
-aTV
-evj
-aWP
-sGL
+xOP
+jXM
+miZ
+fpo
+ljE
+trG
 cva
 cva
 cva
@@ -87236,11 +87437,11 @@ qJd
 edR
 aOE
 mBI
-aRi
-aSu
-aTU
-lZH
-rst
+emj
+aAw
+liG
+rXX
+qLF
 mPK
 gZY
 gZY
@@ -87493,11 +87694,11 @@ aMa
 tau
 xGa
 mBI
-aRl
-aSx
-aTX
-evj
-xIW
+doF
+ivB
+lze
+fpo
+mOr
 gKT
 cva
 cvp
@@ -87552,7 +87753,7 @@ mXb
 ccw
 cig
 iZM
-ecB
+lKy
 cig
 cig
 nPv
@@ -87712,7 +87913,7 @@ acv
 adi
 adi
 aaZ
-omQ
+vQD
 nPy
 eqd
 eke
@@ -87750,11 +87951,11 @@ aLZ
 cTf
 aOE
 heh
-xsM
-wTP
-qsw
-muN
-qeB
+iyZ
+iRs
+lDy
+nCv
+ksx
 gKT
 cva
 fpD
@@ -88007,11 +88208,11 @@ aMc
 xIy
 aOE
 mBI
-aRn
-aSz
-aTY
-nrj
-aWT
+sih
+xbr
+bpZ
+spU
+lyF
 dWX
 cva
 rfO
@@ -88264,11 +88465,11 @@ gnx
 fmJ
 aOE
 mBI
-aRm
-aSy
-aTX
-qNv
-spP
+wtn
+hIr
+lze
+kFL
+ezd
 aPR
 cva
 dIq
@@ -88327,7 +88528,7 @@ nzY
 oUX
 bhv
 wKq
-cnv
+hLs
 xHS
 xHS
 xHS
@@ -88521,11 +88722,11 @@ aMe
 jKA
 aOE
 nDb
-svZ
-qBH
-nOM
-tGX
-pfg
+wpC
+fSJ
+uIP
+fsK
+bWU
 clg
 cva
 rPE
@@ -88778,11 +88979,11 @@ aMd
 iKt
 aOE
 mBI
-aRo
-aSA
-aTX
-evj
-jml
+xJP
+oQx
+lze
+fpo
+rBI
 dLU
 cva
 cvr
@@ -89035,11 +89236,11 @@ aMf
 fYM
 xGa
 mBI
-aRr
-aSD
-ceh
-tYO
-dMP
+jyI
+kxr
+vNV
+wTH
+npt
 dLU
 cva
 krS
@@ -89092,9 +89293,9 @@ jlI
 cfb
 cfH
 cSL
-cim
-cim
-ceo
+dkH
+dkH
+rVi
 cfb
 cfa
 pyN
@@ -89263,7 +89464,7 @@ ajc
 hUs
 akp
 agj
-alA
+iZu
 amm
 lnL
 anw
@@ -89292,11 +89493,11 @@ aJq
 edR
 aOE
 mBI
-aRq
-aSC
-aUa
-ltD
-aWW
+hUG
+xLC
+ceU
+luK
+eSc
 nNM
 pQR
 pQR
@@ -89349,9 +89550,9 @@ bYO
 sbD
 cgO
 ccj
-cBM
-cdU
-cSZ
+wXa
+mim
+nre
 xhV
 cmF
 pyN
@@ -89549,12 +89750,12 @@ aJq
 edR
 aOE
 vvu
-aRs
-aSE
-aUc
-evj
-aWY
-nrV
+qLo
+xAx
+uAf
+fpo
+xkZ
+jMs
 cva
 cva
 xHE
@@ -89584,7 +89785,7 @@ bGE
 bCv
 vPz
 bKy
-bEv
+lmH
 jqU
 bNQ
 bOV
@@ -89606,9 +89807,9 @@ bZg
 glP
 ptx
 wud
-jEk
-cio
-cjY
+vEY
+gXX
+cUd
 wSK
 clQ
 pyN
@@ -89808,10 +90009,10 @@ ugy
 aPR
 aPR
 aPR
-aUb
-tIN
-aWM
-qjl
+iHR
+vwu
+lPe
+iGy
 aZV
 bbo
 hiF
@@ -89853,7 +90054,7 @@ kYO
 pwM
 sOd
 bLK
-bYK
+cVc
 iWN
 eLL
 wZG
@@ -89861,7 +90062,7 @@ mFQ
 hLf
 bZt
 nfl
-cbp
+qBZ
 ccj
 llY
 sIY
@@ -90018,7 +90219,7 @@ aaf
 aaa
 abp
 abP
-aco
+uEp
 acO
 abl
 abO
@@ -90065,10 +90266,10 @@ aOE
 jOW
 aaa
 aPR
-aUe
-cRo
-oLs
-fga
+ltQ
+fIb
+phk
+wrV
 bJQ
 mNx
 oOy
@@ -90079,9 +90280,9 @@ bgU
 bdk
 mIb
 blc
-bmz
-bnY
-bpk
+cCg
+qBR
+gZQ
 bqJ
 vnl
 qWE
@@ -90289,7 +90490,7 @@ dDx
 uhY
 xJQ
 fxO
-aks
+whE
 agj
 agj
 agj
@@ -90322,10 +90523,10 @@ aOE
 jOW
 aaa
 aPR
-aUd
-aVr
-sDt
-aYq
+fRA
+cuS
+fyQ
+orY
 aZW
 jMD
 bej
@@ -90335,10 +90536,10 @@ bfA
 bgT
 bil
 bej
-jJl
-bmy
-bnX
-bpj
+hyw
+uZs
+rYv
+ssY
 bqI
 bsi
 uzM
@@ -90366,7 +90567,7 @@ sUV
 bUI
 wPl
 bWQ
-nbK
+oxr
 rri
 cmp
 bTi
@@ -90581,21 +90782,21 @@ aaa
 aPR
 aPR
 aPR
-bHY
+lEe
 aPR
 aZV
-vrm
-baQ
-baQ
-bcQ
+enm
+oTh
+oTh
+phH
 bfC
 bgV
 bim
 bjG
 aZV
-vYo
-bnZ
-bpl
+ukY
+bfC
+kka
 bqH
 bsl
 vRW
@@ -90837,14 +91038,14 @@ jOW
 aaa
 aaa
 aPR
-mNs
-xqY
-uAo
+lnY
+kyt
+gsW
 aZV
-eKm
-baP
-bbZ
-bcP
+osa
+hJB
+kxU
+pRS
 cBo
 bbw
 bbw
@@ -90895,7 +91096,7 @@ aeQ
 afs
 ahx
 ccw
-aiL
+qFp
 fuW
 ajI
 ajL
@@ -91095,13 +91296,13 @@ aaa
 aaa
 aTQ
 qBW
-kpS
+mqO
 aVd
 aZV
-gBd
-nUe
-nUe
-qpl
+nMc
+cDa
+cDa
+jCJ
 mkM
 pxk
 mkM
@@ -91384,7 +91585,7 @@ uNo
 eqt
 bKB
 bLK
-mll
+nir
 bNV
 vkI
 bQj
@@ -91559,11 +91760,11 @@ aaa
 aaa
 aaf
 abq
-mgJ
-wzV
-acR
-rYW
-rdT
+qZc
+hUd
+itt
+ntd
+sqe
 xiF
 afh
 afV
@@ -91816,11 +92017,11 @@ aaf
 aaf
 aaf
 tAo
-abS
-acr
-acQ
-adn
-uDN
+keQ
+vVe
+vJs
+cDk
+cUv
 abq
 afg
 afU
@@ -92073,12 +92274,12 @@ aaa
 aaa
 aaf
 qvL
-xgS
-itZ
-muW
-miF
-uvt
-fBS
+vRR
+nmZ
+bZA
+aZd
+ejg
+wme
 vHh
 wBI
 tqN
@@ -92127,7 +92328,7 @@ dMB
 aYG
 rNR
 aYG
-aYG
+eal
 bdn
 bep
 aYG
@@ -92136,9 +92337,9 @@ aYG
 aYG
 iVQ
 bmE
-bmE
-bpn
 hqy
+bpn
+bmE
 bsp
 fNV
 gSy
@@ -92330,11 +92531,11 @@ aaf
 aaf
 aaf
 lim
-abU
-act
-rBA
-acu
-rky
+tLn
+oBl
+nNp
+sND
+wnz
 abq
 afi
 afW
@@ -92393,10 +92594,10 @@ eQb
 eQb
 eQb
 eQb
-eQb
-eQb
 hRd
 eQb
+eQb
+hPo
 dmB
 eQb
 eQb
@@ -92587,11 +92788,11 @@ aaa
 aaa
 aaf
 abq
-abW
-abk
-acj
-acn
-okd
+mzK
+jAF
+siD
+lCk
+fbk
 hrb
 afk
 afZ
@@ -92650,12 +92851,12 @@ aJq
 aJq
 iTJ
 bmS
-bmS
-bmS
 wnx
-bqN
-aNr
-aJq
+bmS
+uDE
+scF
+jkc
+hNL
 aJq
 bxL
 byX
@@ -92909,10 +93110,10 @@ bfF
 bfF
 bfF
 bfF
-bfF
-bqM
-brV
-bof
+iZf
+pky
+pxs
+bfH
 bwv
 bvj
 bvj
@@ -93165,10 +93366,10 @@ gwG
 blf
 bmF
 bob
-bha
+jiD
 bfF
-bqR
-brX
+wzu
+bqQ
 bof
 bwx
 bvj
@@ -93424,9 +93625,9 @@ nju
 nju
 nju
 jbE
-qmI
+nOU
 bLX
-ltk
+wFd
 bui
 bvi
 bww
@@ -93675,7 +93876,7 @@ aYV
 bfF
 fmp
 owD
-bgP
+dAn
 jVL
 bkL
 pAR
@@ -93690,7 +93891,7 @@ bwE
 bxc
 bzb
 bzK
-bBb
+rpG
 cpG
 bDC
 bId
@@ -94198,7 +94399,7 @@ bfF
 tcd
 bEe
 bBL
-bwA
+ewV
 bvj
 bAl
 bAl
@@ -94712,7 +94913,7 @@ bqP
 laL
 bEe
 bvh
-bwC
+hez
 bxN
 bze
 aVf
@@ -94960,7 +95161,7 @@ bet
 bfG
 bhe
 bit
-bjS
+bli
 bli
 bli
 ljY
@@ -94976,7 +95177,7 @@ buk
 yey
 buk
 bDZ
-bCK
+eqg
 bFy
 bFF
 bvd
@@ -95205,7 +95406,7 @@ aQe
 aOL
 aOL
 aOL
-aOL
+euY
 aOL
 aOL
 aXO
@@ -95217,7 +95418,7 @@ bet
 bfG
 bhe
 bhh
-bjU
+bAc
 blk
 blk
 lFk
@@ -95227,15 +95428,15 @@ mNI
 bss
 nLu
 buk
-bvm
+ukn
 bDT
-iUa
+mLa
 bvj
 bzU
 bBe
 bCS
 bDE
-bFK
+qhN
 bvd
 mRC
 bzs
@@ -95483,10 +95684,10 @@ bhh
 eMR
 bsr
 bvh
-bwD
+iUa
 bDR
 bDR
-akY
+iTF
 bvj
 bCQ
 ovs
@@ -95734,7 +95935,7 @@ biu
 bjT
 blm
 bmL
-boi
+bhh
 bpw
 bhh
 eMR
@@ -95990,7 +96191,7 @@ bhh
 bhh
 bgQ
 bll
-bhh
+iKn
 bhh
 qFS
 bhh
@@ -96225,15 +96426,15 @@ aaa
 alP
 unD
 kOO
-aJx
-aJx
-aMi
+pJU
+pJU
+rdv
 aNE
 jjb
 aQi
 aRz
 aSF
-aQc
+qQW
 aQc
 aXl
 aQc
@@ -96247,8 +96448,8 @@ ogj
 bhh
 bhg
 bln
-bmM
-boj
+cGR
+sHX
 bof
 bhh
 eMR
@@ -96483,7 +96684,7 @@ alP
 mwD
 aHM
 aJm
-aKz
+adr
 mjr
 aND
 aJC
@@ -96763,7 +96964,7 @@ bjX
 mgc
 bmO
 bhi
-bpy
+tlq
 bwz
 waW
 btZ
@@ -96773,9 +96974,9 @@ bxV
 bzj
 bAv
 bvj
-bCO
+ghi
 bDR
-bDR
+bvm
 bDR
 bIn
 bJC
@@ -97271,13 +97472,13 @@ aYV
 eYV
 aYV
 bfK
-toc
+sSb
 biy
 bjY
 bjN
 bkO
 bmU
-bnH
+ckI
 bqQ
 eMR
 bhh
@@ -97797,7 +97998,7 @@ eMR
 bst
 nAh
 bhh
-bhh
+mDQ
 cdz
 bhh
 bhh
@@ -98848,7 +99049,7 @@ bNi
 bOr
 bWZ
 bYd
-bYY
+vmJ
 bZP
 jET
 bWo
@@ -99076,10 +99277,10 @@ tFL
 tFL
 pwb
 bmX
+bua
 tiO
-tiO
-tiO
-tiO
+bua
+bua
 noc
 bul
 vhn
@@ -99336,7 +99537,7 @@ qsH
 qvp
 fbD
 uvN
-tiO
+bua
 tiO
 buq
 dlK
@@ -99599,9 +99800,9 @@ ifl
 bvr
 bzo
 ljx
-aFa
+lLj
 bCY
-bEh
+gpH
 bCW
 bDS
 bFN
@@ -99854,14 +100055,14 @@ hXS
 btl
 kcE
 bvw
-gWr
+tMQ
 ljx
-aEA
-bCZ
-bEk
-bFG
+bXM
+jpy
+mFm
+qhZ
 bCY
-bFP
+eMo
 bBN
 bKQ
 vPz
@@ -100113,9 +100314,9 @@ pmL
 vhn
 lWm
 ljx
-bBO
+rLH
 bCY
-bEj
+rgE
 bCY
 bGZ
 bFE
@@ -102161,7 +102362,7 @@ wjI
 bls
 bfT
 boD
-bpY
+fPh
 bsP
 box
 btw
@@ -102180,7 +102381,7 @@ bKX
 bMh
 wOT
 bOx
-bPz
+vCJ
 bJN
 bRU
 bEm
@@ -102403,8 +102604,8 @@ aRN
 aIt
 aUB
 aFu
-mpK
-tGd
+tSW
+wgY
 aFu
 aFu
 tZY
@@ -102654,14 +102855,14 @@ aJP
 aLg
 aMH
 aIt
-aYW
-aYW
-aYW
-aYW
-aYW
-aYW
-aVY
-aYY
+jsn
+jsn
+jsn
+jsn
+jsn
+jsn
+mKG
+hiO
 bas
 aFu
 aYV
@@ -102911,14 +103112,14 @@ aJS
 aJS
 aMJ
 aNP
-aOS
-aOS
-aOS
-aOS
-aOS
-aOS
-aWb
-aXU
+gLp
+gLp
+gLp
+gLp
+gLp
+gLp
+jdf
+miY
 bau
 aFu
 aYV
@@ -103174,8 +103375,8 @@ aRO
 aRO
 aUC
 aVP
-aXu
-aYW
+kcI
+jsn
 bat
 bbD
 aYV
@@ -103431,8 +103632,8 @@ aRO
 aRO
 aIt
 aVQ
-aXu
-aYW
+kcI
+jsn
 aVQ
 aFu
 aYV
@@ -103447,7 +103648,7 @@ blG
 biL
 cHV
 cIa
-biL
+dqq
 box
 buo
 gAy
@@ -103688,8 +103889,8 @@ aRP
 aIt
 aIt
 aIt
-aWd
-aXV
+rGL
+xlh
 aIt
 bbD
 aYV
@@ -103710,7 +103911,7 @@ iOe
 xTe
 byi
 bzz
-xbe
+gTi
 bBY
 bDc
 bEo
@@ -103945,8 +104146,8 @@ aFu
 aTc
 aUD
 aVS
-aYW
-aYW
+jsn
+jsn
 bax
 aFu
 aYV
@@ -104202,8 +104403,8 @@ aFu
 nAU
 vtb
 aVR
-aYW
-aYW
+jsn
+jsn
 aUD
 bbD
 aYV
@@ -104215,7 +104416,7 @@ biN
 biL
 bni
 blM
-bou
+cbb
 cHX
 cIc
 biL
@@ -104459,8 +104660,8 @@ aRQ
 aIt
 aUF
 aLg
-aYW
-aYW
+jsn
+jsn
 aVQ
 aFu
 aYV
@@ -104472,7 +104673,7 @@ biQ
 biL
 blC
 bou
-cHT
+bou
 bou
 cId
 biL
@@ -104716,8 +104917,8 @@ aFu
 gPQ
 aUE
 aVT
-aYW
-aYW
+jsn
+jsn
 vcF
 aFu
 aYV
@@ -104973,8 +105174,8 @@ aCR
 aCR
 aCR
 aCR
-iDt
-reu
+esP
+hdc
 aCR
 aCR
 mYQ
@@ -105230,8 +105431,8 @@ qET
 aTe
 aUG
 aFz
-aRS
-aXW
+xdM
+hjK
 baz
 aCR
 bcx
@@ -105487,13 +105688,13 @@ aPl
 aTg
 aUI
 aTg
-aRS
-aZf
+xdM
+pqw
 aFz
 bbF
 aYV
 aXq
-aYV
+xyp
 bfX
 bhB
 bgp
@@ -105514,7 +105715,7 @@ dWM
 pTg
 oeo
 oeM
-dEv
+svq
 hWR
 kmP
 dRW
@@ -105537,7 +105738,7 @@ suU
 wSV
 cIo
 oMN
-won
+uLc
 lFS
 agP
 hkj
@@ -105744,9 +105945,9 @@ aPk
 aTf
 aUH
 aTf
-aRS
-aZf
-aRS
+xdM
+pqw
+xdM
 bbF
 aYV
 aXq
@@ -105776,7 +105977,7 @@ fno
 bBD
 sgy
 bBD
-bBD
+fLm
 bBD
 bPK
 orw
@@ -105997,13 +106198,13 @@ aMM
 aFz
 aFz
 lqJ
-aRS
-aRS
-aRS
-aRS
-aRS
-aZf
-aRS
+xdM
+xdM
+xdM
+xdM
+xdM
+pqw
+xdM
 bbF
 aYV
 aXq
@@ -106049,7 +106250,7 @@ itG
 eZT
 nXX
 fgH
-puT
+mqT
 xkX
 gdx
 lFS
@@ -106254,25 +106455,25 @@ aML
 aFz
 aFz
 aQw
-aRS
-aRS
-aRS
-aRS
-aRS
-aZf
-aRS
+xdM
+xdM
+xdM
+xdM
+xdM
+pqw
+xdM
 bbF
 aYV
 aXq
 aYV
 bfX
 wUF
-biU
-qWs
+nex
+biW
 blI
 bnn
 opq
-oHp
+ogK
 boB
 txX
 gwt
@@ -106511,13 +106712,13 @@ aEh
 aFz
 aFz
 lqJ
-cdl
-aRS
-aRS
-aRS
-aRS
-aZf
-aRS
+tyT
+xdM
+xdM
+xdM
+xdM
+pqw
+xdM
 bbF
 aYV
 aXq
@@ -106772,9 +106973,9 @@ aPn
 aTi
 aUK
 aVU
-aWg
-aZf
-aRS
+lEs
+pqw
+xdM
 bbF
 aYV
 bdv
@@ -106786,7 +106987,7 @@ biW
 blJ
 bno
 boA
-biW
+wEC
 mxA
 bqf
 buo
@@ -107029,8 +107230,8 @@ aPm
 aTh
 aUJ
 aTh
-aXz
-aZg
+gnA
+cTd
 aFz
 bbF
 ldg
@@ -107286,8 +107487,8 @@ aCR
 aTj
 aFz
 aVV
-aXB
-aZh
+kPN
+nwk
 baB
 aCR
 fJF
@@ -107297,7 +107498,7 @@ bgc
 lJC
 biW
 bkv
-blL
+biW
 biW
 tPC
 biW
@@ -107329,7 +107530,7 @@ bQZ
 cMR
 cMR
 frv
-bOv
+gjS
 bQZ
 cOe
 cou
@@ -107543,8 +107744,8 @@ aCR
 aCR
 aCR
 aCR
-vLX
-wDo
+xcs
+kTY
 aCR
 aCR
 aTk
@@ -107557,7 +107758,7 @@ vSb
 kyi
 lht
 lEi
-cPs
+fPC
 boB
 bth
 nJQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

read title

## Why It's Good For The Game

2 down 6 to go

## Changelog
:cl:
add: colored carpets for heads of staff rooms, additional newscasters, emergency holopads, and a second medbay entrance have 
 been added to boxstation
fix: some wall mounts that borked on box's random engines have been unborked.
/:cl: