### PR TITLE
Galaxystation 2.0

### DIFF
--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -10011,8 +10011,8 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "gDi" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/holopad/emergency/bar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "gDS" = (
@@ -10551,7 +10551,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -10562,6 +10561,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/holopad/emergency/medical,
 /turf/open/floor/plasteel/white,
 /area/medical)
 "hzq" = (
@@ -11363,6 +11363,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"iCS" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/holopad/emergency/science,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "iDQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13597,6 +13602,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"lQU" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/holopad/emergency/medical,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "lRn" = (
 /obj/machinery/light{
 	dir = 4
@@ -14080,6 +14095,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mPt" = (
@@ -16467,6 +16483,7 @@
 "pJH" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon/wayfinding/hop,
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pKm" = (
@@ -21666,8 +21683,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xaL" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/holopad/emergency/science,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "xct" = (
@@ -53271,7 +53288,7 @@ oUk
 oUk
 cbo
 xye
-eIk
+iCS
 alO
 avG
 anh
@@ -57634,7 +57651,7 @@ anT
 anT
 anT
 ahD
-aiL
+lQU
 aTj
 ajy
 aHn

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -332,12 +332,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "acs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "acu" = (
@@ -465,16 +459,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"adm" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm3";
-	name = "Dorm 3"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "ado" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -822,13 +806,11 @@
 /turf/open/floor/plasteel,
 /area/medical)
 "afl" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/red,
-/area/crew_quarters/dorms)
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood,
+/area/library)
 "aft" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1257,6 +1239,10 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/structure/sign/departments/chemistry{
+	pixel_x = 32;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -2842,14 +2828,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "apY" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "aqb" = (
 /turf/closed/wall,
@@ -3209,9 +3192,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "arL" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "arM" = (
 /obj/item/circuitboard/computer/nanite_chamber_control,
@@ -3311,6 +3296,14 @@
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
 /area/maintenance/aft)
+"asF" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "asM" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -3892,11 +3885,17 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "azf" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/spawner/lootdrop/gloves,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/carpet/red,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/library)
 "azj" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -4225,25 +4224,10 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"aEk" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Dorm 2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "aEp" = (
-/obj/structure/sign/poster/random{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/dorms)
+/obj/machinery/bookbinder,
+/turf/open/floor/wood,
+/area/library)
 "aEs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -4261,12 +4245,16 @@
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "aEI" = (
-/obj/item/bedsheet/dorms,
+/obj/structure/curtain/cloth/grey,
 /obj/structure/bed,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/item/bedsheet/dorms,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aEN" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -4455,15 +4443,9 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aHf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/chair/office,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "aHh" = (
 /obj/structure/table/wood,
@@ -5282,6 +5264,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -23;
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aRy" = (
@@ -5300,8 +5287,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aSg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aSm" = (
@@ -5374,6 +5365,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aTs" = (
@@ -5497,11 +5489,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aUW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -5557,11 +5549,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -5581,15 +5573,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "aWs" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/red,
-/area/crew_quarters/dorms)
+/turf/open/floor/wood,
+/area/library)
 "aWu" = (
 /obj/structure/table/wood/fancy,
 /obj/item/paicard,
@@ -5694,13 +5682,11 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "aYE" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm1";
-	name = "Dorm 1"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock{
+	name = "Dormitory"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aYX" = (
@@ -5710,6 +5696,12 @@
 "aZa" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
+"aZh" = (
+/obj/structure/sign/directions/upload{
+	pixel_y = -5
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai_upload)
 "aZq" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -6144,6 +6136,19 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"bAh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "bBI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6344,13 +6349,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"bLA" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "bPh" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -6670,6 +6668,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/head_of_personnel)
+"ccT" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/library)
 "ceK" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -6923,6 +6925,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"cvK" = (
+/turf/open/floor/wood,
+/area/library)
 "cvU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7037,13 +7042,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cAq" = (
-/obj/machinery/newscaster/security_unit{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
 "cBT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -7116,11 +7114,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -7350,6 +7345,15 @@
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
+"cXn" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/library)
 "cZb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Plasma to Pure"
@@ -8995,10 +8999,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "fqa" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
+/obj/structure/bookcase/random/religion,
+/obj/item/book/codex_gigas,
+/turf/open/floor/wood,
+/area/library)
 "fqI" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -9186,25 +9190,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"fGB" = (
-/obj/machinery/button/door{
-	id = "Dorm2";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
-	specialfunctions = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/machinery/computer/bookmanagement,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/crew_quarters/dorms)
 "fGK" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 8
@@ -10015,6 +10000,14 @@
 /obj/machinery/holopad/emergency/bar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"gDk" = (
+/obj/structure/chair/pew/right,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/carpet/red,
+/area/library)
 "gDS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -10330,6 +10323,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"heH" = (
+/obj/structure/curtain/cloth/grey,
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "hfa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -10682,6 +10688,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hHO" = (
@@ -10755,6 +10762,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"hNz" = (
+/obj/machinery/libraryscanner,
+/turf/open/floor/wood,
+/area/library)
 "hOv" = (
 /obj/structure/chair/office,
 /obj/machinery/button/massdriver{
@@ -11040,6 +11051,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"icn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/library)
 "icQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11099,12 +11116,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ifT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Dormitories - Lower";
 	name = "dormitories camera"
@@ -11112,6 +11123,12 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -11632,7 +11649,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "iZg" = (
-/obj/effect/landmark/observer_start,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
@@ -11976,6 +11992,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"jvv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "jwV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -12456,21 +12483,21 @@
 /turf/open/floor/plating,
 /area/crew_quarters/toilet)
 "kdv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/structure/table/wood,
+/obj/item/storage/book/bible,
+/obj/machinery/door/window/eastleft{
+	name = "Display Case";
+	req_access_txt = "22"
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/storage/crayons,
-/obj/item/choice_beacon/hero,
-/obj/item/book/codex_gigas,
-/obj/structure/closet/crate/secure{
-	name = "library crate";
-	req_access_txt = "37"
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/nullrod,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/area/library)
 "kdG" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -13577,6 +13604,7 @@
 "lQa" = (
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/newscaster{
+	pixel_x = -4;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -13614,20 +13642,10 @@
 /area/medical/medbay/lobby)
 "lRn" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/newscaster/security_unit{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/crew_quarters/dorms)
+/turf/open/floor/carpet/red,
+/area/library)
 "lUu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13662,6 +13680,18 @@
 "lWe" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel,
+/area/maintenance/aft)
+"lYm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/departments/custodian{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "lZk" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
@@ -13779,6 +13809,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
+"mmQ" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/library)
 "mnP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -14127,7 +14161,7 @@
 /obj/machinery/light_switch{
 	dir = 6;
 	pixel_x = 23;
-	pixel_y = -23
+	pixel_y = 23
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -14154,7 +14188,7 @@
 /obj/machinery/light_switch{
 	dir = 6;
 	pixel_x = 23;
-	pixel_y = -23
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -14309,11 +14343,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	dir = 5;
-	pixel_x = 23;
-	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -14968,6 +14997,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/sign/departments/engineering{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -15697,6 +15729,9 @@
 	name = "hallway camera"
 	},
 /obj/machinery/computer/warrant,
+/obj/structure/sign/departments/security{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oRy" = (
@@ -15867,6 +15902,9 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/comms)
+"oZP" = (
+/turf/closed/wall,
+/area/library)
 "paw" = (
 /obj/structure/chair{
 	dir = 4
@@ -16036,14 +16074,23 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "phr" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/machinery/newscaster/security_unit{
-	dir = 8;
-	pixel_x = -30
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/library)
 "phU" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -16361,6 +16408,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/sign/departments/nanites{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "pAq" = (
@@ -16394,9 +16444,8 @@
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -27
+/obj/structure/sign/departments/xenobio{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
@@ -16412,6 +16461,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -16445,6 +16500,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"pGh" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/sign/departments/botany{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "pHH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -17143,23 +17205,19 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "qJf" = (
-/obj/machinery/button/door{
-	id = "Dorm3";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
-	specialfunctions = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/item/bedsheet/dorms,
-/obj/structure/bed,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/library)
 "qJk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17225,6 +17283,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"qLQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qLZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17350,6 +17425,14 @@
 "rcN" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/crew_quarters/dorms)
+"rdc" = (
+/obj/machinery/door/airlock{
+	name = "Multipurpose Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/library)
 "req" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -17403,6 +17486,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"rio" = (
+/obj/effect/landmark/start/librarian,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "rjd" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17895,6 +17985,20 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/brig)
+"rOM" = (
+/obj/structure/sign/directions/vault{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/upload{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/medical/medbay/lobby)
 "rPj" = (
 /obj/machinery/door/airlock{
 	name = "Bar Backroom";
@@ -18347,6 +18451,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"sAE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/sign/departments/science{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "sBI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18602,14 +18724,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"sXG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "sYG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18710,14 +18824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tdg" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
 "tdo" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -19716,6 +19822,15 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating/airless,
 /area/space)
+"uEl" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/library)
 "uFj" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
@@ -19779,6 +19894,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"uJT" = (
+/obj/structure/curtain/cloth/grey,
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "uKo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -19881,6 +20002,7 @@
 /area/science/mixing)
 "uTM" = (
 /obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "uTT" = (
@@ -20260,10 +20382,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "vop" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/maintenance/aft)
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/library)
 "vov" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -20513,6 +20634,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
+"vFq" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/wood,
+/area/library)
 "vGl" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -20885,6 +21013,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wiX" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/obj/structure/sign/directions/upload{
+	dir = 1;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/vault{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/closed/wall,
+/area/storage/primary)
 "wjO" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine,
@@ -21222,10 +21364,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"wFL" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "wGV" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -21492,6 +21630,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wUL" = (
@@ -21599,17 +21738,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wYT" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/landmark/start/librarian,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/obj/structure/chair/pew/left,
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/carpet/red,
+/area/library)
 "wYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/purple{
@@ -21659,6 +21791,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/sign/departments/evac{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "xaJ" = (
@@ -21834,25 +21969,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/warden)
-"xql" = (
-/obj/machinery/button/door{
-	id = "Dorm1";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
-	specialfunctions = 4
-	},
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/head/kitty,
-/obj/item/clothing/suit/toggle/lawyer,
-/obj/item/clothing/suit/jacket/letterman_nanotrasen,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
 "xrA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43264,7 +43380,7 @@ gxw
 jai
 smg
 akz
-akR
+aZh
 alt
 pyV
 qfi
@@ -47624,7 +47740,7 @@ qoj
 ffR
 aIU
 oJv
-fwn
+qLQ
 nlA
 fSy
 kmZ
@@ -50989,7 +51105,7 @@ rkv
 mzF
 mff
 jNp
-tdr
+bAh
 tdr
 iyp
 iDQ
@@ -51229,10 +51345,10 @@ aJb
 ado
 vHb
 ado
-aJb
+wiX
 pdV
 pdV
-pdV
+sAE
 alJ
 alJ
 alJ
@@ -56629,7 +56745,7 @@ aiv
 aiv
 kVM
 xye
-uFj
+pGh
 alS
 amA
 qFs
@@ -58939,7 +59055,7 @@ aiv
 aiv
 aiv
 aiv
-aiv
+rOM
 cCk
 xye
 uDo
@@ -59215,7 +59331,7 @@ xHz
 uPI
 mpH
 xHz
-xHz
+lYm
 jGt
 aqS
 aqT
@@ -62550,8 +62666,8 @@ jtN
 apj
 pEH
 apj
-xql
-cAq
+uJT
+uJT
 aEI
 apj
 gkg
@@ -62810,8 +62926,8 @@ aYE
 apY
 aHf
 arL
-apj
-eHm
+asF
+jvv
 hra
 aqS
 aqT
@@ -63064,9 +63180,9 @@ gpV
 apj
 kEJ
 apj
-apj
-apj
-apj
+heH
+uJT
+uJT
 apj
 eHm
 dab
@@ -63320,11 +63436,11 @@ ykj
 jtN
 apj
 nwd
-apj
-fGB
-bLA
-wFL
-apj
+oZP
+oZP
+oZP
+oZP
+oZP
 eHm
 aqR
 aqS
@@ -63577,11 +63693,11 @@ ebU
 wBl
 apj
 ifT
-aEk
+oZP
 wYT
 lRn
 kdv
-apj
+oZP
 gkg
 aaN
 aqS
@@ -63834,11 +63950,11 @@ nYy
 blk
 apj
 aJv
-apj
-apj
-apj
-apj
-apj
+oZP
+gDk
+icn
+uEl
+oZP
 pEh
 aqS
 aqS
@@ -64091,11 +64207,11 @@ xct
 gew
 apj
 aVW
-apj
+rdc
 qJf
 phr
 azf
-apj
+cXn
 cDR
 uLi
 aqT
@@ -64348,11 +64464,11 @@ rUy
 aEy
 apj
 aUW
-adm
+oZP
 afl
 aWs
 aEp
-apj
+oZP
 pja
 aqR
 aqT
@@ -64605,11 +64721,11 @@ kut
 sYG
 hAM
 aSg
-apj
-apj
-apj
-apj
-apj
+oZP
+vFq
+cvK
+hNz
+oZP
 fAq
 jPs
 aqT
@@ -64862,11 +64978,11 @@ sUw
 lMo
 aEy
 acs
-tdg
-atR
-atR
+oZP
+ccT
+cvK
 vop
-sXG
+oZP
 arX
 mrx
 aqT
@@ -65119,11 +65235,11 @@ apj
 apj
 apj
 aVr
-apj
+oZP
 fqa
-hra
-aqR
-aqR
+rio
+mmQ
+oZP
 aqS
 aqS
 aqT
@@ -65376,11 +65492,11 @@ apm
 apm
 apj
 apj
-apj
-aqS
-aqS
-aqS
-aqS
+oZP
+oZP
+oZP
+oZP
+oZP
 aqS
 aqT
 aqT

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -1000,6 +1000,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "agJ" = (
@@ -1262,6 +1266,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ahP" = (
@@ -1439,6 +1446,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -2101,6 +2114,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "alI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "alJ" = (
@@ -3946,6 +3960,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "azB" = (
@@ -4081,8 +4101,9 @@
 /area/crew_quarters/heads/head_of_personnel)
 "aBJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aBK" = (
 /obj/machinery/grill/unwrenched,
 /turf/open/floor/plating,
@@ -5337,6 +5358,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"aSt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "aSO" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel/dark,
@@ -5799,7 +5824,7 @@
 /obj/item/beacon,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "bfV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5853,6 +5878,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bkB" = (
@@ -6866,6 +6892,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"cmb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "cmG" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -7170,6 +7205,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -7552,6 +7593,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "ddb" = (
@@ -7694,7 +7741,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "dro" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7850,7 +7897,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -8020,11 +8067,25 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dEW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -8325,7 +8386,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "efK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8458,6 +8519,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"emA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/tank/carbon_dioxide,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "enj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8884,6 +8959,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eKQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eLB" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
@@ -8928,6 +9019,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"eOS" = (
+/mob/living/simple_animal/bot/secbot/pingsky,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai_upload)
 "ePH" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -9138,7 +9233,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "fhp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10353,9 +10448,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"gSO" = (
-/turf/open/space/basic,
-/area/space/nearstation)
 "gUh" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -10504,6 +10596,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hcY" = (
@@ -10599,6 +10697,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "hiq" = (
@@ -10625,7 +10726,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "hjb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -10734,7 +10835,7 @@
 /area/maintenance/aft)
 "hru" = (
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "hsQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
@@ -10907,11 +11008,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -10961,6 +11066,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
@@ -11243,7 +11354,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "hZx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -11463,6 +11574,12 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -11742,7 +11859,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "iKY" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -12034,7 +12151,7 @@
 /area/medical/sleeper)
 "jdG" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/science/test_area)
 "jdI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
@@ -12117,7 +12234,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "jjX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -12275,11 +12392,23 @@
 "jtK" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/science/misc_lab)
+/area/space/nearstation)
 "jtN" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"juj" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "juQ" = (
 /obj/structure/table/reinforced,
 /obj/structure/sign/warning/nosmoking{
@@ -12494,7 +12623,7 @@
 	},
 /obj/item/target,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "jGt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -13079,7 +13208,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
@@ -13655,6 +13784,16 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"liU" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "ljZ" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -13918,6 +14057,12 @@
 	dir = 6;
 	pixel_x = 23;
 	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -14362,6 +14507,22 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"mwt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "mwD" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -14468,6 +14629,12 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -15098,6 +15265,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ntO" = (
@@ -15276,8 +15449,13 @@
 /area/engine/atmos)
 "nBh" = (
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
@@ -16275,6 +16453,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "oUk" = (
@@ -16398,10 +16580,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"oZD" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "oZE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16419,7 +16597,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "pcT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -16775,6 +16953,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "prX" = (
@@ -16932,6 +17116,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -17161,7 +17349,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "pMm" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch{
@@ -17321,6 +17509,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "pYi" = (
@@ -17401,6 +17592,12 @@
 	dir = 10;
 	pixel_x = -23;
 	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -18085,6 +18282,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rkv" = (
@@ -18214,13 +18414,19 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "rpS" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/engine/transit_tube)
+/area/space/nearstation)
 "rrd" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18823,7 +19029,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "scr" = (
 /obj/machinery/telecomms/processor/preset_three,
-/obj/machinery/atmospherics/pipe/simple/cyan{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
 	},
 /turf/open/floor/circuit/green/telecomms,
@@ -19123,6 +19329,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sCn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "sCE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -19493,9 +19705,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tdo" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "tdr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -19542,6 +19751,22 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"tgn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "thj" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -20683,7 +20908,7 @@
 	},
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "uSN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -21061,6 +21286,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "voi" = (
@@ -21191,7 +21420,7 @@
 /area/engine/break_room)
 "vrA" = (
 /turf/closed/indestructible/opshuttle,
-/area/space)
+/area/science/test_area)
 "vtg" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -21251,7 +21480,7 @@
 "vzX" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "vAM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance";
@@ -21449,6 +21678,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vQF" = (
@@ -21505,7 +21740,7 @@
 	},
 /obj/item/target,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "vVr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -21622,18 +21857,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"waV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4;
-	name = "cooling Loop Input"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/comms)
 "wbO" = (
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
@@ -22265,6 +22494,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "wSx" = (
@@ -22398,6 +22633,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "wXz" = (
@@ -22427,6 +22666,10 @@
 /obj/machinery/camera{
 	c_tag = "Engineering - Transit Tube Access";
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
@@ -22573,6 +22816,12 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xaL" = (
@@ -22604,6 +22853,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -22646,6 +22898,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/science/storage)
+"xfD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xji" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -23170,7 +23438,7 @@
 "xOT" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "xOV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23578,6 +23846,12 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"yiH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "yiJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42376,7 +42650,7 @@ ahI
 avF
 ahI
 aiO
-pXC
+cmb
 aiO
 ahI
 ahI
@@ -42633,7 +42907,7 @@ aKr
 fTG
 pOR
 aiO
-pXC
+cmb
 aiO
 aNS
 ahI
@@ -42890,7 +43164,7 @@ ahI
 aGK
 ahI
 aiO
-wui
+juj
 aiO
 xJB
 ahI
@@ -43147,7 +43421,7 @@ ahI
 ahI
 ahI
 dZk
-pXC
+cmb
 aiO
 kTr
 ahI
@@ -43392,16 +43666,16 @@ aaa
 sGo
 sxG
 tjp
-waV
+lmn
 jFc
 myk
 jHE
 ahI
 aiO
-ajk
-ajk
-ajk
-ajk
+aSt
+sCn
+sCn
+sCn
 dEW
 bjS
 hhf
@@ -43906,7 +44180,7 @@ aaa
 aaa
 sxG
 sxG
-sxG
+hZx
 hZx
 sxG
 rzm
@@ -44420,12 +44694,12 @@ aaa
 aaa
 agD
 qwB
-ahg
-ahg
+eKQ
+tgn
 saZ
 ahg
 ahg
-ahg
+xfD
 wYb
 hRN
 fHm
@@ -44433,7 +44707,7 @@ alI
 waH
 avB
 anz
-anY
+eOS
 anY
 aoN
 akR
@@ -44677,8 +44951,8 @@ aaa
 aaa
 agD
 vxt
-ahg
-ahg
+eKQ
+mwt
 cDf
 pzU
 pzU
@@ -44933,7 +45207,7 @@ aaa
 aaa
 aaa
 agD
-ahh
+emA
 ahK
 aie
 aiC
@@ -44941,7 +45215,7 @@ ahh
 bQq
 agD
 ggD
-akR
+agD
 alv
 rrp
 amL
@@ -45198,7 +45472,7 @@ mZW
 agD
 agD
 eyu
-akR
+agD
 akR
 akR
 akR
@@ -45453,9 +45727,9 @@ afZ
 mFX
 ahj
 afZ
-tdo
+agD
 doz
-tdo
+agD
 afZ
 afZ
 afZ
@@ -45959,7 +46233,7 @@ aaa
 aaa
 aeE
 aaa
-gSO
+aaa
 afZ
 ahl
 afZ
@@ -46474,7 +46748,7 @@ ecn
 uDV
 agb
 xUB
-xUB
+liU
 xUB
 hPR
 fbV
@@ -46736,7 +47010,7 @@ nBh
 wXM
 agG
 rpz
-tKT
+yiH
 tKT
 ovq
 vad
@@ -50930,9 +51204,9 @@ aaa
 aaa
 aaa
 aaa
-oZD
+aga
 aaa
-oZD
+aga
 aaa
 aaa
 aaa
@@ -51187,9 +51461,9 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 aaa
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -51444,9 +51718,9 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 aaa
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -51700,11 +51974,11 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 xOT
 jdG
 xOT
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -51956,13 +52230,13 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 jdG
 xOT
 jFz
 xOT
 jdG
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -52162,57 +52436,57 @@ vhe
 vhe
 dyA
 fxf
-bAb
-bAb
-oZD
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-oZD
-bAb
-bAb
+afZ
+afZ
+aga
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+aga
+afZ
+afZ
 xOT
 xOT
 paw
@@ -52220,9 +52494,9 @@ hir
 pMc
 xOT
 xOT
-bAb
-bAb
-oZD
+afZ
+afZ
+aga
 aaa
 aaa
 aaa
@@ -52676,57 +52950,57 @@ fxf
 fxf
 fxf
 fxf
-bAb
-bAb
-oZD
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-bAb
-oZD
-bAb
-bAb
+afZ
+afZ
+aga
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+aga
+afZ
+afZ
 xOT
 xOT
 fgu
@@ -52734,9 +53008,9 @@ vzX
 efz
 xOT
 xOT
-bAb
-bAb
-oZD
+afZ
+afZ
+aga
 aaa
 aaa
 aaa
@@ -52984,13 +53258,13 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 jdG
 xOT
 vUm
 xOT
 jdG
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -53242,11 +53516,11 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 xOT
 jdG
 xOT
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -53500,9 +53774,9 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 aaa
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -53757,9 +54031,9 @@ aaa
 aaa
 aaa
 aaa
-bAb
+afZ
 aaa
-bAb
+afZ
 aaa
 aaa
 aaa
@@ -54014,9 +54288,9 @@ aaa
 aaa
 aaa
 aaa
-oZD
+aga
 aaa
-oZD
+aga
 aaa
 aaa
 aaa

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -1770,6 +1770,9 @@
 "akd" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "akh" = (
@@ -3296,6 +3299,12 @@
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
 /area/maintenance/aft)
+"asx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "asF" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -3627,9 +3636,6 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "awd" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
@@ -4226,6 +4232,9 @@
 /area/engine/atmos)
 "aEp" = (
 /obj/machinery/bookbinder,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/library)
 "aEs" = (
@@ -4631,6 +4640,12 @@
 "aIA" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"aIC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aII" = (
 /obj/machinery/light{
 	dir = 1
@@ -4723,6 +4738,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aJP" = (
@@ -4744,10 +4762,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "aKg" = (
-/obj/machinery/light/small,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aKr" = (
@@ -5863,6 +5881,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "boB" = (
@@ -6332,6 +6353,9 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/survival,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine/atmos)
 "bLl" = (
@@ -6503,6 +6527,7 @@
 "bXt" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bXN" = (
@@ -6643,6 +6668,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"ccq" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "ccu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -6687,6 +6718,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"ceL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "cfr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -6871,6 +6908,9 @@
 /area/hallway/secondary/command)
 "ctd" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7773,6 +7813,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dyA" = (
@@ -8248,6 +8291,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
 "ehN" = (
@@ -8335,6 +8381,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eoM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "eoX" = (
 /obj/structure/table/wood,
 /obj/structure/cable{
@@ -8483,6 +8536,12 @@
 /obj/machinery/navbeacon/wayfinding/bar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"ewx" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ewF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -8520,6 +8579,7 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "eyw" = (
@@ -8684,6 +8744,12 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eJZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "eKA" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -8918,6 +8984,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"ffF" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/engine,
+/area/science/storage)
 "ffR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8991,6 +9063,9 @@
 /obj/item/pickaxe{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
@@ -9437,9 +9512,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "fUB" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
@@ -10336,6 +10408,25 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"heO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/crew_quarters/dorms)
 "hfa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -10472,6 +10563,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "hnV" = (
@@ -10689,6 +10783,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hHO" = (
@@ -10828,6 +10925,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"hRI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "hRN" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "MiniSat Upload";
@@ -11057,6 +11160,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/library)
+"icD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "icQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11141,6 +11250,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"igU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "ihx" = (
 /obj/structure/closet/wardrobe/science_white,
 /obj/effect/turf_decal/delivery,
@@ -11150,6 +11265,9 @@
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -11233,6 +11351,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
+"inh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "inK" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -11466,6 +11594,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "iJK" = (
@@ -11495,6 +11626,9 @@
 "iOH" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -11804,8 +11938,23 @@
 	dir = 4
 	},
 /obj/machinery/vending/snack/random,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"jgF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "jiO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -11940,6 +12089,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"jtK" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "jtN" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -12301,6 +12454,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jRt" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "jSv" = (
 /obj/item/radio/intercom{
 	pixel_x = 26
@@ -12423,6 +12584,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jZr" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "jZS" = (
 /obj/machinery/computer/teleporter,
 /obj/effect/turf_decal/stripes/line{
@@ -12636,6 +12801,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kld" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kmX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13034,6 +13206,7 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/item/clothing/mask/gas,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "kKk" = (
@@ -13050,6 +13223,9 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Toxins Maintenance";
 	req_access_txt = "8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
@@ -14989,6 +15165,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "nNX" = (
@@ -15053,6 +15232,18 @@
 "nUY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"nWL" = (
+/turf/closed/wall/r_wall,
+/area/library)
+"nWX" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -15258,6 +15449,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins - Mixing Area";
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -15576,6 +15772,9 @@
 "oGV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "oHP" = (
@@ -15656,6 +15855,10 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -15873,6 +16076,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"oYH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "oZo" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -16071,6 +16280,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "phr" = (
@@ -16224,6 +16434,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"poX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/department/science)
 "ppo" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner,
@@ -16926,6 +17145,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qml" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qnH" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/holopad,
@@ -17178,6 +17401,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qGp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "qGu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -17219,9 +17448,6 @@
 /turf/open/floor/plasteel,
 /area/library)
 "qJk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/science,
@@ -17420,6 +17646,13 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/science,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins - Launch Area";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "rcN" = (
@@ -17703,6 +17936,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"rxn" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins Storage";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "rxU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -18278,6 +18523,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"slY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "smg" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/computer/telecomms/monitor{
@@ -18757,6 +19008,9 @@
 /area/hydroponics)
 "sZy" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "tal" = (
@@ -19099,6 +19353,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"tAn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "tAE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -19410,6 +19671,11 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tYk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tYA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -20244,6 +20510,9 @@
 /area/science/xenobiology)
 "veg" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "vff" = (
@@ -20847,6 +21116,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/obj/machinery/camera{
+	c_tag = "Toxins - Lab";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vYj" = (
@@ -21109,6 +21382,9 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "wsi" = (
@@ -21281,6 +21557,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/research)
+"wyv" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "wyA" = (
 /obj/machinery/light_switch{
 	dir = 6;
@@ -21330,6 +21613,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wBy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "wDG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -21545,6 +21834,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wTE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wTH" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Quarters";
@@ -21672,6 +21967,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"wXM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Transit Tube Access";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "wYb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -21846,7 +22154,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xen" = (
@@ -22038,6 +22345,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xsE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xtA" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -22161,6 +22474,9 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xzE" = (
@@ -22441,7 +22757,7 @@
 /area/hallway/primary/central)
 "xPZ" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
-/turf/open/space/basic,
+/turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "xQq" = (
 /obj/structure/cable{
@@ -45943,7 +46259,7 @@ agb
 tKT
 wSj
 nBh
-agG
+wXM
 agG
 rpz
 tKT
@@ -46216,7 +46532,7 @@ aaa
 afZ
 aIA
 aIg
-aIg
+asx
 fmR
 gCM
 aaC
@@ -46713,13 +47029,13 @@ ccu
 ccu
 fjS
 hcm
-nlA
+tYk
 fSy
+ffF
 wsz
-wsz
 fir
 fir
-fir
+jRt
 fir
 fSy
 mMg
@@ -47236,7 +47552,7 @@ iUM
 fGL
 nRO
 fSy
-mMg
+jZr
 mMg
 efW
 mMg
@@ -47244,7 +47560,7 @@ mMg
 mMg
 aIA
 aIg
-aIg
+slY
 fmR
 gCM
 vfo
@@ -47493,7 +47809,7 @@ qAq
 eLB
 eik
 fSy
-mMg
+wyv
 iin
 oiP
 mMg
@@ -47746,7 +48062,7 @@ fSy
 kmZ
 nMx
 tfc
-tfc
+rxn
 shE
 con
 fSy
@@ -47767,7 +48083,7 @@ aHD
 gNw
 gNw
 gNw
-aKg
+gNw
 aIA
 aaa
 aaa
@@ -48007,7 +48323,7 @@ fSy
 fSy
 fSy
 fSy
-uMm
+wBy
 rgc
 oFE
 mQL
@@ -48262,9 +48578,9 @@ xjJ
 mgV
 fZb
 jOG
-uMm
-uMm
-gDS
+ccq
+igU
+eoM
 aUy
 oFE
 aEN
@@ -48519,7 +48835,7 @@ uMm
 uMm
 fZb
 xyT
-bay
+icD
 iln
 iln
 kQm
@@ -48776,7 +49092,7 @@ bay
 uMm
 fZb
 bay
-gDS
+tAn
 iln
 bAb
 xPZ
@@ -49033,7 +49349,7 @@ uMm
 bay
 nUY
 uMm
-bay
+icD
 hFH
 bAb
 xPZ
@@ -49290,7 +49606,7 @@ bay
 bay
 fZb
 mqr
-uMm
+wBy
 iln
 bAb
 xPZ
@@ -49547,7 +49863,7 @@ fZb
 fZb
 fZb
 bay
-uMm
+wBy
 iln
 iln
 kQm
@@ -49800,11 +50116,11 @@ jaE
 cmG
 wTm
 gDS
-uMm
+eJZ
 gDS
 uMm
 bay
-bay
+icD
 qAU
 gDS
 bhW
@@ -49815,7 +50131,7 @@ mlb
 gmP
 oFE
 ihx
-mHc
+inh
 aFx
 nyp
 jre
@@ -50058,10 +50374,10 @@ olX
 abv
 tbp
 cuM
-bay
-bay
-gDS
-uMm
+ewx
+xsE
+kld
+ceL
 bay
 iVz
 qAU
@@ -50315,7 +50631,7 @@ aJb
 aJb
 aJb
 aJb
-nUY
+nWX
 aJb
 aJb
 weB
@@ -50324,7 +50640,7 @@ bay
 bay
 uMm
 bay
-bay
+wTE
 bay
 afL
 oFE
@@ -50572,7 +50888,7 @@ tsw
 bPP
 uAR
 dCR
-aRj
+qGp
 dyC
 aJb
 aiF
@@ -50840,7 +51156,7 @@ uhb
 aAD
 azj
 aLm
-aLm
+poX
 aAD
 aPe
 rRX
@@ -51094,7 +51410,7 @@ aec
 eIk
 aEV
 acn
-azj
+aIC
 qJk
 awq
 arM
@@ -51625,10 +51941,10 @@ bBI
 aEV
 bPh
 fXY
-kvw
+oYH
 kvw
 lne
-kvw
+jtK
 aaa
 aaa
 aaa
@@ -55440,7 +55756,7 @@ aaa
 aaa
 qss
 aYD
-wOP
+hRI
 hkZ
 abV
 bZv
@@ -59305,7 +59621,7 @@ vhS
 oHP
 qin
 vhS
-oHT
+jgF
 oHT
 vhS
 vhS
@@ -60616,7 +60932,7 @@ arF
 apd
 eHm
 hra
-aqR
+qml
 aqS
 aqT
 aaa
@@ -62156,7 +62472,7 @@ att
 dvC
 lNf
 aHi
-imM
+heO
 ehr
 hHO
 cUC
@@ -63442,7 +63758,7 @@ oZP
 oZP
 oZP
 eHm
-aqR
+qml
 aqS
 aqT
 aaa
@@ -65749,11 +66065,11 @@ afZ
 apm
 apm
 apm
-apm
-aqT
-aqT
-aqT
-aqT
+nWL
+nWL
+nWL
+nWL
+nWL
 aqT
 aqT
 aaa

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -7,11 +7,8 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aaf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/mob/living/simple_animal/slime,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aal" = (
 /obj/structure/bed,
@@ -85,14 +82,16 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "aaC" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	name = "kill chamber window"
+/obj/item/radio/intercom{
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/caution{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/engine/hull,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aaD" = (
 /turf/closed/wall/r_wall,
@@ -607,6 +606,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical)
+"aen" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "aeo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -680,14 +686,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "aeJ" = (
 /obj/machinery/rnd/experimentor,
@@ -870,6 +875,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"afL" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "afM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -1045,8 +1055,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ahc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -1197,6 +1208,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ahD" = (
@@ -1372,6 +1384,9 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1957,6 +1972,9 @@
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"aln" = (
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "alo" = (
 /obj/machinery/button/door{
 	id = "armouryaccess";
@@ -2995,6 +3013,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
+"aqL" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "aqQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -3190,15 +3220,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"arQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "arR" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
@@ -3233,6 +3254,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -3307,13 +3331,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "asN" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "asR" = (
 /obj/effect/turf_decal/tile/blue,
@@ -3399,14 +3417,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "atC" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -3432,12 +3446,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "atQ" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/blue,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/screwdriver{
+	pixel_y = 16
+	},
+/obj/item/wrench,
+/obj/item/multitool{
+	pixel_x = 3
+	},
+/obj/machinery/light,
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/t_scanner,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "atR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3561,8 +3586,8 @@
 /turf/open/floor/carpet/royalblue,
 /area/ai_monitored/turret_protected/ai_upload)
 "avC" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "avE" = (
@@ -3604,9 +3629,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
-"avN" = (
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "avV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
 /turf/open/floor/engine/plasma,
@@ -3690,17 +3712,6 @@
 	dir = 1
 	},
 /area/hallway/primary/central)
-"awY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
-	name = "containment blast door"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "axn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -3777,6 +3788,18 @@
 	name = "Containment Pen #1";
 	req_access_txt = "55"
 	},
+/obj/machinery/door/window/southleft{
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "axV" = (
@@ -3790,9 +3813,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "axX" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/requests_console{
+	department = "Tool Storage";
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "axZ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -3819,6 +3848,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ayh" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/xenoblood,
+/obj/machinery/igniter{
+	id = "xenoigniter";
+	luminosity = 2
+	},
+/turf/open/floor/circuit/green,
+/area/science/xenobiology)
 "ayo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3918,11 +3956,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"azJ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "aAh" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/reagentgrinder{
 	pixel_x = -1;
 	pixel_y = 8
@@ -3982,19 +4021,21 @@
 /area/ai_monitored/security/armory)
 "aAS" = (
 /mob/living/simple_animal/slime,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aAU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aBj" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -4005,15 +4046,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"aBy" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #2";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/obj/machinery/light/small,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "aBz" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -4046,6 +4078,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
@@ -4160,17 +4195,6 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"aDf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "aDp" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
@@ -4244,23 +4268,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/dorms)
+"aEN" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "aEV" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
-"aEY" = (
-/obj/machinery/door/window/southleft{
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
-	name = "containment blast door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "aEZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4270,6 +4284,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -4305,7 +4322,10 @@
 /area/security/main)
 "aFk" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -4356,24 +4376,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aGg" = (
-/obj/machinery/door/window/southleft{
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "aGi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGj" = (
@@ -4489,8 +4492,8 @@
 /obj/structure/sign/directions/supply{
 	dir = 8
 	},
-/turf/closed/wall,
-/area/storage/primary)
+/turf/closed/wall/r_wall,
+/area/storage/tech)
 "aHv" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -4512,8 +4515,20 @@
 "aHD" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
-	name = "Containment Pen #3";
+	name = "Containment Pen #2";
 	req_access_txt = "55"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -4722,14 +4737,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"aJH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "aJM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4755,12 +4762,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "aKg" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #3";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
 /obj/machinery/light/small,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aKr" = (
@@ -4803,15 +4808,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aKG" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/obj/machinery/light/small,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "aKN" = (
 /obj/machinery/computer/cargo,
 /obj/machinery/light{
@@ -4819,19 +4815,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/head_of_personnel)
-"aKO" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "aKU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4918,8 +4901,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aLy" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -4985,14 +4969,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"aMi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
-	name = "containment blast door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "aMn" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue,
@@ -5092,6 +5068,12 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -5323,15 +5305,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aSm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/minisat{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "aSO" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel/dark,
@@ -5388,6 +5369,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"aTp" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "aTs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/syndicatebomb/training,
@@ -5490,6 +5478,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"aUy" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "aUB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output,
 /turf/open/floor/engine/n2,
@@ -5546,23 +5542,16 @@
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
-"aVS" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "aVU" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "aVW" = (
 /obj/machinery/light{
@@ -5581,6 +5570,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"aWb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "aWd" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
@@ -5638,6 +5633,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aXp" = (
@@ -5714,20 +5710,6 @@
 "aZa" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
-"aZd" = (
-/obj/machinery/door/window/southleft{
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "aZq" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -5747,20 +5729,29 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aZM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aZZ" = (
 /obj/machinery/rnd/bepis,
 /turf/open/floor/engine,
 /area/science/explab)
+"bas" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hallway/primary/central)
+"bay" = (
+/turf/open/floor/plating,
+/area/maintenance/port)
+"bbh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "bbu" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
@@ -5777,6 +5768,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"beu" = (
+/obj/item/beacon,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/space)
 "bfV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5795,6 +5791,10 @@
 "bgS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine/atmos)
+"bhW" = (
+/obj/structure/girder,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "bix" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
@@ -5838,6 +5838,10 @@
 /obj/item/book/manual/wiki/atmospherics,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"bkZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "blk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -5852,22 +5856,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bnk" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Science Maintenance";
-	req_one_access_txt = "12;47"
+"bni" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Toxins Storage";
+	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/engine,
+/area/science/storage)
 "boB" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "boG" = (
@@ -5950,6 +5958,24 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"brU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"buu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"buF" = (
+/obj/machinery/igniter/incinerator_toxmix,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "buM" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
@@ -5973,9 +5999,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6094,6 +6117,52 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"byj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"bAb" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"bBI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Science Maintenance";
+	req_one_access_txt = "12;47"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "bCi" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -6217,6 +6286,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"bIh" = (
+/turf/closed/wall/r_wall,
+/area/security/checkpoint)
 "bJn" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
@@ -6279,6 +6351,9 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"bPh" = (
+/turf/closed/wall,
+/area/science/misc_lab)
 "bPl" = (
 /obj/item/bedsheet/head_of_personnel,
 /obj/structure/bed,
@@ -6311,6 +6386,28 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"bPZ" = (
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
+"bQq" = (
+/obj/machinery/camera{
+	c_tag = "AI Satellite - Antechamber";
+	dir = 8;
+	name = "ai camera";
+	network = list("minisat");
+	start_active = 1
+	},
+/obj/machinery/computer/message_monitor{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "bRi" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/south,
@@ -6349,14 +6446,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bUi" = (
-/obj/machinery/vending/tool,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/camera{
-	c_tag = "Primary Tool Storage";
-	dir = 8
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/storage/tech)
 "bWx" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -6409,6 +6502,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"bXt" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "bXN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -6453,9 +6551,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bYL" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6466,8 +6561,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bZs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "bZv" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -6534,6 +6639,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"cbO" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
+"ccu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ccN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -6558,6 +6685,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"cfr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "cgG" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/snack/random,
@@ -6657,6 +6793,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"cmG" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"cnb" = (
+/obj/machinery/air_sensor/atmos/toxins_mixing_tank,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cnP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -6680,6 +6824,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"con" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "cpM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Chemistry Maintenance";
@@ -6699,17 +6850,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/fore)
-"cqz" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "crV" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/blue,
@@ -6727,6 +6867,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"ctd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "ctC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/auto_name/west{
@@ -6758,6 +6904,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cuM" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "cvG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -6875,8 +7025,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "czH" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "cAq" = (
 /obj/machinery/newscaster/security_unit{
@@ -6984,6 +7143,23 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"cHK" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_one_access_txt = "24;10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cIc" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cIt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 1
@@ -6996,6 +7172,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"cIV" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cKC" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -7115,6 +7297,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cTN" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "cUC" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -7163,13 +7350,6 @@
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
-"cXW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "cZb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Plasma to Pure"
@@ -7249,6 +7429,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"dcL" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/service,
+/turf/open/floor/plasteel,
+/area/storage/tech)
+"dcM" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Transit Tube Access";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "ddb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -7288,6 +7489,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"ddZ" = (
+/obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
+"dfw" = (
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/blue,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "dgG" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/auto_name/east,
@@ -7363,6 +7580,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"doz" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "13;32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space/nearstation)
 "dro" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7456,6 +7683,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hos)
+"dut" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Mixing Lab";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "dvC" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light{
@@ -7470,6 +7716,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
+"dwB" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "dwQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -7509,6 +7764,42 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"dxt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"dyA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/doppler_array/research/science{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
+"dyC" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel,
+/area/storage/primary)
+"dCk" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #5";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "dCm" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Coldroom";
@@ -7554,6 +7845,20 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
+"dCR" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "dEx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -7682,6 +7987,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/research)
+"dRm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "dRO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7737,6 +8050,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/bar)
+"dUY" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dVo" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -7836,11 +8154,6 @@
 "ecP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
-/obj/machinery/light_switch{
-	dir = 10;
-	pixel_x = -23;
-	pixel_y = -23
-	},
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
@@ -7872,6 +8185,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"efz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "efK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7892,6 +8214,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
+"efW" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "egg" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/kirbyplants/random,
@@ -7936,6 +8262,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"eik" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/science/storage)
 "eiH" = (
 /obj/machinery/telecomms/server/presets/common/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -7973,6 +8304,18 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"emo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "enj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7982,6 +8325,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -8129,22 +8475,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"evK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ewm" = (
 /obj/machinery/navbeacon/wayfinding/bar,
 /turf/open/floor/plasteel/dark,
@@ -8182,6 +8512,12 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eyu" = (
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eyw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8293,10 +8629,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eFV" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "eHc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -8357,6 +8703,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eLB" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine,
+/area/science/storage)
 "eMz" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -8565,10 +8915,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "ffR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
+	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fga" = (
@@ -8576,6 +8938,44 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
+"fgu" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"fhp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
+"fir" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/science/storage)
+"fjS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fld" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/rack,
@@ -8590,6 +8990,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
+"fmR" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "fqa" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -8691,6 +9095,34 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"fvM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"fwn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fwo" = (
 /obj/machinery/shower{
 	dir = 1
@@ -8711,6 +9143,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"fxf" = (
+/turf/closed/wall/r_wall,
+/area/science/misc_lab)
 "fAq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8723,6 +9158,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"fCj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	name = "killroom vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "fFt" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Mix to Ports"
@@ -8731,6 +9175,14 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -31
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Pumps";
+	dir = 4;
+	name = "atmospherics camera"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -8769,6 +9221,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fGL" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "fHm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8871,6 +9330,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"fLO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fMh" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -8895,21 +9363,66 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"fMs" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/crowbar,
-/obj/machinery/light{
+"fMi" = (
+/obj/machinery/door/window/southleft{
+	name = "Xenobiology Kill Chamber";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Xenobiology Kill Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/caution,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/item/storage/belt/utility,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/science/xenobiology)
+"fMs" = (
+/obj/machinery/door/window/brigdoor/security{
+	req_access_txt = "19;23"
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/tech)
+"fOx" = (
+/obj/structure/table/reinforced,
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "fQh" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"fSy" = (
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "fTG" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -8938,6 +9451,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"fUB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
+"fVt" = (
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fWK" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8948,25 +9483,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
-"fXO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"fXY" = (
+/obj/machinery/mass_driver{
+	id = "toxinsdriver"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/science/misc_lab)
+"fZb" = (
+/turf/closed/wall,
+/area/maintenance/port)
 "fZV" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -9065,6 +9590,23 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ggD" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = -32
+	},
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "13;32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "giv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9099,6 +9641,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"gjT" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "gkf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -9164,6 +9719,24 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"gmP" = (
+/turf/closed/wall,
+/area/science/mixing/chamber)
+"gny" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"goc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9237,6 +9810,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gtk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gtm" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -9249,8 +9839,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gtx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "gtV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -9273,6 +9870,30 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"gul" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Aft";
+	name = "atmospherics camera"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gxq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -9345,6 +9966,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
+"gCM" = (
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"gCV" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #2";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "gDc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -9357,11 +10003,25 @@
 	dir = 1
 	},
 /area/hallway/primary/central)
+"gDd" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "gDi" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"gDS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"gEQ" = (
+/turf/open/floor/engine,
+/area/science/storage)
 "gFk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9373,6 +10033,12 @@
 /obj/machinery/navbeacon/wayfinding/med,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"gGm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "gHy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -9416,6 +10082,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"gMh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gMl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -9437,6 +10120,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"gNw" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "gOX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9473,6 +10162,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"gSO" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "gUh" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -9577,6 +10269,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"gZM" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
+	dir = 1;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "hcd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
@@ -9594,6 +10296,25 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/bridge)
+"hcm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hcY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
 /turf/open/floor/plasteel/dark,
@@ -9675,6 +10396,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"hir" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "hjb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -9731,11 +10459,15 @@
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
 "hmB" = (
-/obj/structure/chair/office{
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "hnV" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -9755,6 +10487,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"hpP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"hqW" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "hra" = (
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
@@ -9907,6 +10655,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hFH" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hFU" = (
 /obj/machinery/telecomms/bus/preset_three,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -9914,10 +10666,24 @@
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/comms)
-"hGg" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+"hGh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hHO" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -9989,6 +10755,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"hOv" = (
+/obj/structure/chair/office,
+/obj/machinery/button/massdriver{
+	id = "toxinsdriver";
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "hPw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -10106,9 +10882,18 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "hWE" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	pixel_y = -26
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -10199,14 +10984,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -10342,6 +11124,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ihx" = (
+/obj/structure/closet/wardrobe/science_white,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"iin" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "iir" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -10376,6 +11170,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"ikK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"iln" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/port)
 "imj" = (
 /obj/structure/rack,
 /obj/item/mmi,
@@ -10438,6 +11247,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"ipS" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iti" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10488,33 +11301,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"ixt" = (
-/obj/machinery/light_switch{
-	dir = 6;
-	pixel_x = 23;
-	pixel_y = -23
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 27
-	},
-/obj/machinery/computer/message_monitor{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "iyp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -10524,8 +11320,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/aft)
+/area/maintenance/department/science)
 "iyz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -10549,12 +11351,26 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"iAx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "iDQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "iFm" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/firealarm{
@@ -10586,6 +11402,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10621,6 +11440,19 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"iJB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"iJK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/space)
 "iKY" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -10638,6 +11470,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/head_of_personnel)
+"iOH" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "iOO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -10654,6 +11492,25 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iQf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iQv" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -10670,6 +11527,17 @@
 /obj/item/circuitboard/mecha/ripley/peripherals,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"iQH" = (
+/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "iTv" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -10698,6 +11566,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"iUM" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/storage)
+"iVz" = (
+/mob/living/simple_animal/hostile/cockroach,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "iWL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
@@ -10705,6 +11584,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iXr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iYq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -10804,6 +11689,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jaE" = (
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "jaP" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -10834,6 +11722,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"jdG" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "jdI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
@@ -10887,6 +11778,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jfB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"jiO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "jjX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -10927,8 +11832,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/head_of_personnel)
 "joE" = (
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jpq" = (
@@ -10994,6 +11902,7 @@
 "jre" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jrv" = (
@@ -11130,6 +12039,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"jBB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "jDh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11151,6 +12067,8 @@
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "jEZ" = (
@@ -11191,6 +12109,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"jFz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/target,
+/turf/open/floor/plating/airless,
+/area/space)
 "jGt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -11228,26 +12156,13 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/comms)
 "jJw" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/medical,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/stack/cable_coil{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/storage/tech)
 "jKr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -11294,8 +12209,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jOG" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "jOP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -11326,11 +12250,23 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jRo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jSv" = (
@@ -11373,6 +12309,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
+"jVd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
+"jWt" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "jWH" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -11539,12 +12492,6 @@
 /obj/item/book/manual/wiki/research_and_development,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"kdU" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "kew" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11597,6 +12544,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"khh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/toxinsmix{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "khL" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "O2 to Airmix"
@@ -11660,6 +12616,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"kmZ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "knn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -11753,6 +12716,9 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ksA" = (
@@ -11774,8 +12740,31 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"kur" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "kut" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -11831,6 +12820,9 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"kvw" = (
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "kxD" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -11988,6 +12980,10 @@
 "kHl" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
+"kIY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/mixing)
 "kJq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -12001,6 +12997,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"kJS" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "kKk" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
@@ -12011,6 +13014,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"kKI" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Toxins Maintenance";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "kNw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -12056,12 +13066,12 @@
 "kPy" = (
 /obj/docking_port/stationary{
 	dir = 2;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+	dwidth = 2;
+	height = 6;
+	id = "monastery_shuttle_station";
+	name = "Station";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/large;
+	width = 5
 	},
 /turf/open/space/basic,
 /area/space)
@@ -12077,6 +13087,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"kQm" = (
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "kTa" = (
 /obj/machinery/light{
 	dir = 8
@@ -12114,6 +13127,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"kVM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/primary/port)
 "kVW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -12143,25 +13168,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kXR" = (
-/obj/structure/table,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/screwdriver{
-	pixel_y = 16
-	},
-/obj/item/t_scanner,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/storage/tech)
 "kYx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12208,6 +13223,11 @@
 	dir = 1
 	},
 /area/hallway/primary/central)
+"lhx" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ljZ" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -12278,6 +13298,13 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/comms)
+"lne" = (
+/obj/machinery/door/poddoor{
+	id = "toxinsdriver";
+	name = "Toxins Launcher Bay Door"
+	},
+/turf/closed/wall/r_wall,
+/area/science/misc_lab)
 "lnY" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -12293,20 +13320,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"lsc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lsd" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -12357,6 +13370,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"lvB" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/engine,
+/area/science/storage)
 "lyT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12391,15 +13417,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"lAZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "lEE" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/stripes/end{
@@ -12420,6 +13437,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"lFg" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/camera{
@@ -12532,13 +13553,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
-"lNl" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lNq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12599,30 +13613,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/crew_quarters/dorms)
-"lRz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/camera{
-	c_tag = "AI Satellite - Antechamber";
-	dir = 8;
-	name = "ai camera";
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "lUu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12730,6 +13720,10 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"mgV" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "mka" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -12749,6 +13743,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"mlb" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mlc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
@@ -12780,6 +13778,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"mpx" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "mpE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -12809,6 +13816,10 @@
 /obj/machinery/navbeacon/wayfinding/janitor,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"mqr" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mrx" = (
 /obj/machinery/atmospherics/pipe/simple/multiz{
 	dir = 1;
@@ -12831,6 +13842,26 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"muC" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Xenobiology Kill Chamber";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Xenobiology Kill Chamber";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "muR" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -12979,6 +14010,24 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"mHc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"mMg" = (
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"mML" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "mNn" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -13011,6 +14060,10 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"mNU" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "mOJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -13087,6 +14140,9 @@
 	pixel_x = 23;
 	pixel_y = -23
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "mQD" = (
@@ -13104,6 +14160,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"mQL" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "mRj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "N2 to Pure"
@@ -13133,20 +14193,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"mTa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mTB" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -13255,14 +14301,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"mVX" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecomms External Port";
-	dir = 8;
-	network = list("tcomms")
-	},
-/turf/open/space/basic,
-/area/space)
 "mWE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig";
@@ -13376,6 +14414,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"nbM" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "ndw" = (
 /obj/machinery/holopad/secure,
 /obj/structure/cable{
@@ -13406,17 +14450,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nfl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "nfr" = (
 /obj/machinery/computer/crew{
@@ -13434,18 +14481,27 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"ngM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "nhy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "nhC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -13531,7 +14587,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/checkpoint)
+/area/storage/tech)
+"nrN" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/minisat{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "nrT" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13541,6 +14608,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"nrV" = (
+/obj/effect/landmark/start/scientist,
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "ntm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13672,6 +14750,9 @@
 	pixel_y = 32;
 	receive_ore_updates = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "nyu" = (
@@ -13710,7 +14791,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "nAP" = (
@@ -13718,6 +14801,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"nBh" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "nCG" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8;
@@ -13755,6 +14845,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -13846,6 +14939,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
+"nMx" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
+"nNX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "nQB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -13858,6 +14967,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"nRO" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "nRZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13868,6 +14984,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nTV" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Secure Chamber";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "nUG" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "O2 to Pure"
@@ -13880,9 +15003,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "nUY" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/port)
 "nXv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14025,6 +15150,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"odR" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/analyzer,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "oeW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14034,6 +15169,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oiP" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "oiT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -14062,6 +15204,23 @@
 /obj/effect/turf_decal/atmos/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"ojn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"ojT" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "okk" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit/green,
@@ -14094,6 +15253,18 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"olX" = (
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "omm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -14104,23 +15275,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
-"omG" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Transit Tube Access";
-	req_one_access_txt = "32;19"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
 "onC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14205,6 +15359,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ovq" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "13;32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "oxE" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -14259,6 +15421,9 @@
 	dir = 4;
 	pixel_y = 24
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ozA" = (
@@ -14295,6 +15460,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"oCt" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/timer{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "oCD" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -14330,30 +15517,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
-"oGd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+"oFE" = (
+/turf/closed/wall,
+/area/science/mixing)
 "oGL" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"oGV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/engine,
+/area/science/storage)
 "oHP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -14383,6 +15559,29 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oJv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oMh" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
@@ -14405,6 +15604,20 @@
 /obj/item/storage/box/ingredients,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"oNP" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/science/storage)
+"oOB" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "oPz" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14427,15 +15640,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Medical";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint - Medical";
+	req_access_txt = "63"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"oPX" = (
+/obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "oQy" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/bed/dogbed/ian,
@@ -14483,6 +15701,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"oSd" = (
+/mob/living/simple_animal/slime,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "oSZ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "MiniSat Upload";
@@ -14498,6 +15723,9 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"oUk" = (
+/turf/closed/wall/r_wall,
+/area/storage/tech)
 "oVq" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -14610,6 +15838,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"oZD" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "oZE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14619,6 +15851,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/comms)
+"paw" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "pcT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -14689,11 +15927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"peJ" = (
-/obj/item/book/manual/wiki/toxins,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "peN" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -14764,13 +15997,10 @@
 /area/security/brig)
 "pgB" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -14782,6 +16012,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"pgW" = (
+/obj/machinery/door/window/eastleft,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "phr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -14928,6 +16165,15 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/central)
+"ppH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "prX" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/structure/lattice/catwalk,
@@ -15090,14 +16336,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
@@ -15117,11 +16363,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"pAU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "pBi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "pEh" = (
@@ -15156,12 +16416,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "pEI" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/engineering,
+/obj/machinery/camera{
+	c_tag = "Technology Storage";
+	dir = 4;
+	name = "engineering camera"
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/storage/tech)
 "pHH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -15265,17 +16532,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
+"pMc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "pMm" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch{
 	dir = 9;
 	pixel_x = -23;
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
+/obj/structure/window/reinforced/spawner,
+/obj/effect/spawner/lootdrop/techstorage/command,
+/obj/effect/spawner/lootdrop/techstorage/RnD_secure,
+/obj/structure/rack,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/tech)
 "pOR" = (
 /obj/machinery/door/window{
 	base_state = "rightsecure";
@@ -15297,10 +16579,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"pQo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+"pPz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"pQo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -15313,11 +16606,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = -26
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"pQW" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "pRk" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -15377,6 +16677,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"pWe" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "pXC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15424,6 +16730,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qdq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"qdF" = (
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "qfi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -15445,6 +16760,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"qgd" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "qhM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -15526,6 +16857,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"qoj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qqh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -15562,12 +16909,21 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "qtv" = (
-/obj/effect/landmark/start/assistant,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/storage/tech)
 "qtU" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/purple,
@@ -15615,6 +16971,22 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qAq" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine,
+/area/science/storage)
+"qAM" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
+"qAU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "qBl" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -15663,6 +17035,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qEF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qFn" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -15828,6 +17220,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"qPK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/item/lightreplacer,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "qQf" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line,
@@ -15907,30 +17309,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"qYD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -15946,6 +17324,12 @@
 /obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"rbI" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "rcN" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -15982,6 +17366,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"rgc" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rhQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16123,20 +17511,32 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "rpf" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "rpz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
+"rpS" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/engine/transit_tube)
+"rrd" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #3";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "rrp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -16166,6 +17566,31 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"ruK" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Site";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
+"rve" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "rvi" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -16367,6 +17792,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"rIQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "rJT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16490,9 +17922,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "rRX" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -27
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
@@ -16550,6 +17987,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"rVo" = (
+/turf/open/floor/circuit/green,
+/area/science/xenobiology)
 "rVJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -16562,6 +18002,13 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"rXU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "rYq" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/status_display/ai{
@@ -16569,9 +18016,31 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
+"rZz" = (
+/obj/machinery/igniter{
+	id = "xenoigniter";
+	luminosity = 2
+	},
+/turf/open/floor/circuit/green,
+/area/science/xenobiology)
 "rZG" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
+"rZU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"sae" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "saf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -16621,6 +18090,13 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
+"shE" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "sie" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/security/brig";
@@ -16639,6 +18115,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"siI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/mixingchamber{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing/chamber)
 "sjD" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /obj/machinery/camera/motion{
@@ -16703,6 +18188,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sqk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"ssC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "suC" = (
 /obj/machinery/airalarm/kitchen_cold_room{
 	pixel_y = 24
@@ -16746,15 +18244,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/aft)
-"svp" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
 "svU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/disposalpipe/segment,
@@ -16810,23 +18299,21 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "syY" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/bot,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
+/obj/structure/window/reinforced/spawner,
+/obj/effect/spawner/lootdrop/techstorage/AI,
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Technology Storage - Secure";
+	dir = 8;
+	name = "engineering camera"
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/tech)
 "szq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -16916,6 +18403,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"sHf" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "sIP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -17069,6 +18563,11 @@
 /obj/machinery/cryopod/latejoin,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
+"sVO" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "sVQ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -17161,6 +18660,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"tbp" = (
+/obj/structure/closet/crate/engineering,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "tbC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17168,9 +18672,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_y = 24
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -17198,6 +18701,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"tdo" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "tdr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -17237,6 +18743,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"tfc" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "thj" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -17277,6 +18790,23 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
+"tnI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "tps" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -17284,9 +18814,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -17313,16 +18840,28 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"tsw" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+"tsn" = (
+/obj/item/radio/intercom{
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/rack,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/wiki/engineering_construction{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"tsw" = (
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "tsx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -17345,9 +18884,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -17439,24 +18977,44 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "tAE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/airlock/security{
 	name = "Security Post";
 	req_access_txt = "63"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"tCf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tCi" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -17517,6 +19075,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tEY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tGY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -17574,9 +19138,17 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"tKT" = (
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "tLO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "tLW" = (
@@ -17638,6 +19210,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"tPI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "tPW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -17680,14 +19264,22 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/science/explab)
-"tVi" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/filingcabinet,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+"tTv" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/mob/living/simple_animal/slime,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"tVi" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "tWJ" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -17770,6 +19362,19 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
+"ucC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "udd" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera{
@@ -17790,6 +19395,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ugj" = (
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "uhb" = (
 /obj/machinery/nanite_program_hub,
 /obj/effect/turf_decal/bot,
@@ -17816,18 +19424,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/fore)
-"uhF" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "uiU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -17861,11 +19457,30 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
-"unQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+"ulK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"umZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #4";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"unQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -17874,6 +19489,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -18015,10 +19633,28 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
+"uxN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "uyq" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
+"uAR" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/crowbar,
+/obj/item/storage/belt/utility,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/item/clothing/head/welding,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "uBx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -18081,6 +19717,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uGy" = (
@@ -18101,6 +19738,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"uJz" = (
+/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/airlock_sensor/incinerator_toxmix{
+	pixel_x = 24
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "uJO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/advanced_airlock_controller{
@@ -18138,6 +19785,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uMm" = (
+/turf/open/floor/plasteel,
+/area/maintenance/port)
+"uMV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "uNl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -18158,6 +19814,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"uRz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uSq" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -18165,37 +19841,46 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"uSH" = (
+/obj/item/target/syndicate,
+/obj/machinery/camera/preset/toxins{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating/airless,
+/area/space)
 "uSN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uTD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"uTM" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "uTT" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/table,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	dir = 5;
-	pixel_x = 23;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "uUt" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "uUK" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -18269,15 +19954,36 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
 "uXu" = (
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uXQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uYU" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -18341,6 +20047,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vad" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "vbo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
@@ -18361,9 +20074,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -18393,6 +20103,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"veg" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
+"vff" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "vfo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18400,8 +20118,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/button/door{
+	id = "misclab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -18436,22 +20164,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"vgR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "vgS" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -18470,6 +20182,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"vhe" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
+"vhh" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "vhS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18622,6 +20350,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"vrA" = (
+/turf/closed/indestructible/opshuttle,
+/area/space)
 "vtg" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -18657,30 +20388,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vxJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
+/obj/item/radio/intercom{
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
-"vyf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/camera{
+	c_tag = "Primary Tool Storage";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18696,6 +20409,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vzX" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/space)
 "vAM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance";
@@ -18769,6 +20486,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"vDT" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "13;32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "vGl" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18779,6 +20506,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
+"vHb" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Primary Tool Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "vIS" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
@@ -18897,6 +20648,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"vUm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/target,
+/turf/open/floor/plating/airless,
+/area/space)
 "vVr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18913,6 +20675,18 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"vVu" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "vWM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -18923,6 +20697,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"vWO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "vYj" = (
 /obj/machinery/light_switch{
 	dir = 9;
@@ -19053,6 +20834,10 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"weB" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "whn" = (
 /obj/machinery/shower{
 	pixel_y = 15
@@ -19083,6 +20868,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wjO" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/engine,
+/area/science/storage)
+"wkK" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/rnd,
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "wmy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -19138,6 +20932,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"wrg" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "wsi" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -19169,6 +20983,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"wsz" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/science/storage)
 "wsP" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/circuit/green,
@@ -19221,6 +21040,34 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
+"wuL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"wvU" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/wrench,
+/obj/machinery/button/ignition{
+	id = "xenoigniter";
+	pixel_y = 7
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "wvY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -19408,6 +21255,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"wJD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "killroom vent"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Kill Chamber";
+	dir = 10;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "wJJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19492,9 +21352,28 @@
 /obj/machinery/navbeacon/wayfinding/sec,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wOL" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "wOP" = (
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"wSj" = (
+/obj/machinery/light_switch{
+	dir = 5;
+	pixel_x = 23;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "wSx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -19504,6 +21383,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"wTm" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Engineering Maintenance";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wTH" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Quarters";
@@ -19549,6 +21435,26 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/bridge)
+"wUf" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "wUo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -19571,6 +21477,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"wUL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "wWQ" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable{
@@ -19723,6 +21644,27 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"xaJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xaL" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -19738,12 +21680,35 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xdl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xen" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"xfc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "xfj" = (
 /obj/machinery/light{
 	dir = 1
@@ -19753,6 +21718,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xfx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/engine,
+/area/science/storage)
+"xji" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
+"xjJ" = (
+/obj/structure/table/reinforced,
+/obj/item/mmi,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xkQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -19826,6 +21804,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"xoB" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "xqh" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -20040,6 +22024,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"xyT" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xzE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -20060,6 +22050,27 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"xDE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Primary Tool Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "xEd" = (
 /obj/machinery/light{
 	dir = 8
@@ -20070,14 +22081,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "xFk" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/navbeacon/wayfinding/minisat_access_tcomms_ai,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "xFG" = (
@@ -20179,6 +22184,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"xKe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "xKT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -20231,6 +22245,10 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/crew_quarters/heads/head_of_personnel)
+"xOT" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating/airless,
+/area/space)
 "xOV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20288,21 +22306,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xPZ" = (
+/obj/machinery/door/poddoor/incinerator_toxmix,
+/turf/open/space/basic,
+/area/science/mixing/chamber)
 "xQq" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/door/airlock/engineering{
+	name = "Technology Storage";
+	req_access_txt = "23"
 	},
-/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/storage/tech)
+"xRp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "xRq" = (
@@ -20319,14 +22340,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Pumps";
-	dir = 1;
-	name = "atmospherics camera"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xUy" = (
@@ -20368,11 +22382,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"xVm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xVZ" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
 	dir = 1
@@ -20421,6 +22438,18 @@
 	},
 /turf/open/floor/plasteel/stairs/medium,
 /area/bridge)
+"xXT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "xXY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -20584,10 +22613,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ygE" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ygJ" = (
@@ -35816,6 +37845,7 @@ aaa
 aaa
 aaa
 aaa
+yib
 aaa
 aaa
 aaa
@@ -35830,8 +37860,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -38125,25 +40154,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+sxG
+sxG
+sxG
+sxG
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -38382,25 +40411,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+sxG
+sxG
+sxG
+sxG
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -38639,25 +40668,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+eiH
+itl
+iKY
+eMO
+ahI
+ahI
+aiN
+aiO
+hZc
+aiO
+dwB
+vtg
+xEd
+hoi
+aiN
+ahI
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -38879,6 +40908,7 @@ aaa
 aaa
 aaa
 aaa
+yib
 aaa
 aaa
 aaa
@@ -38895,26 +40925,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+saj
+xwK
+xwK
+bXZ
+ahI
+ahI
+aiO
+aiO
+aiO
+aiO
+iYN
+aiO
+aiO
+iYN
+aiO
+ahI
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -39153,25 +41182,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+jHG
+xwK
+xwK
+frz
+ahI
+aiy
+aiO
+ajk
+ajk
+ajk
+wui
+ajk
+ajk
+pXC
+aiO
+anx
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -39410,25 +41439,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+cKR
+xwK
+huu
+wHe
+ahI
+ahI
+aiO
+ajk
+aiO
+ahI
+avF
+ahI
+aiO
+pXC
+aiO
+ahI
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -39667,25 +41696,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+sjD
+xwK
+gPS
+sxG
+ahI
+ahI
+hzq
+ajk
+aiO
+aKr
+fTG
+pOR
+aiO
+pXC
+aiO
+aNS
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -39924,6 +41953,25 @@ aaa
 aaa
 aaa
 aaa
+sxG
+kxD
+ndw
+cWb
+xoc
+lKN
+ahI
+aiO
+ajl
+aiO
+ahI
+aGK
+ahI
+aiO
+wui
+aiO
+xJB
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -39939,26 +41987,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -40181,25 +42210,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+mwD
+lmn
+hFU
+myk
+oZE
+ahI
+jYi
+ajk
+lFe
+ahI
+ahI
+ahI
+dZk
+pXC
+aiO
+kTr
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -40437,26 +42466,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sGo
+sxG
+tjp
+waV
+jFc
+myk
+jHE
+ahI
+aiO
+ajk
+ajk
+ajk
+ajk
+dEW
+bjS
+hhf
+aiO
+aiz
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -40695,25 +42724,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+scr
+koI
+fga
+myk
+oZE
+ahI
+aiN
+aiO
+aiO
+aiO
+asS
+lKa
+aiO
+aiO
+aiN
+ahI
+ahI
+ahI
 aaa
 aaa
 aaa
@@ -40950,27 +42979,27 @@ aaa
 aaa
 aaa
 aaa
-yib
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-yib
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxG
+sxG
+sxG
+hZx
+sxG
+rzm
+agD
+agD
+agD
+akR
+akR
+akR
+azy
+akR
+akR
+akR
+akR
+akR
+akR
 aaa
 aaa
 aaa
@@ -41196,7 +43225,6 @@ aaa
 aaa
 aaa
 aaa
-yib
 aaa
 aaa
 aaa
@@ -41210,24 +43238,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-yib
-aaa
-aaa
+agD
+jZS
+xdl
+gjT
+dIh
+gxw
+jai
+smg
+akz
+akR
+alt
+pyV
+qfi
+alu
+gru
+rYq
+anY
+aoM
+akR
 aaa
 aaa
 aaa
@@ -41466,25 +43495,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agD
+qwB
+ahg
+ahg
+saZ
+ahg
+ahg
+ahg
+wYb
+hRN
+fHm
+alI
+waH
+avB
+anz
+anY
+anY
+aoN
+akR
 aaa
 aaa
 aaa
@@ -41723,25 +43752,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agD
+vxt
+ahg
+ahg
+cDf
+pzU
+pzU
+xaJ
+pzU
+oSZ
+vku
+wWQ
+ntm
+rjd
+anz
+anZ
+anY
+dCE
+akR
 aaa
 aaa
 aaa
@@ -41980,6 +44009,25 @@ aaa
 aaa
 aaa
 aaa
+agD
+ahh
+ahK
+aie
+aiC
+ahh
+bQq
+agD
+ggD
+akR
+alv
+rrp
+amL
+hkY
+amg
+nau
+apa
+aoP
+akR
 aaa
 aaa
 aaa
@@ -41988,25 +44036,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-yib
 aaa
 aaa
 aaa
@@ -42237,25 +44266,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agD
+tWJ
+vKa
+vKa
+vPd
+mZW
+agD
+agD
+eyu
+akR
+akR
+akR
+akR
+akR
+akR
+akR
+akR
+akR
+akR
 aaa
 aaa
 aaa
@@ -42494,25 +44523,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afZ
+ahj
+afZ
+afZ
+mFX
+ahj
+afZ
+tdo
+doz
+tdo
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
+afZ
 aaa
 aaa
 aaa
@@ -42725,7 +44754,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -42751,25 +44780,25 @@ aaa
 aaa
 aaa
 aaa
+afZ
+aiQ
 aaa
 aaa
-mVX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mFX
+aiQ
+afZ
+afZ
+aga
 aaa
 aaa
 aaa
 aaa
+afZ
 aaa
 aaa
 aaa
+aaa
+afZ
 aaa
 aaa
 aaa
@@ -42990,7 +45019,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -43007,26 +45036,26 @@ aaa
 aaa
 aeE
 aaa
+gSO
+afZ
+ahl
+afZ
+afZ
+mFX
+ahl
+afZ
+afZ
+aga
+afZ
+afZ
+afZ
+afZ
+afZ
 aaa
-sxG
-sxG
-sxG
-sxG
-sxG
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
+aaa
+aaa
+aaa
+afZ
 aaa
 aaa
 aaa
@@ -43263,28 +45292,28 @@ aXW
 hru
 hru
 hru
-aXW
+agb
+rpS
+agE
+ahm
+agE
+agE
+imB
+aiR
+agE
+afZ
+aga
+aga
+aga
+afZ
+afZ
+afZ
 aaa
-sxG
-sxG
-sxG
-sxG
-sxG
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
-ahI
 aaa
+aaa
+aaa
+afZ
+afZ
 aIA
 hru
 hru
@@ -43520,29 +45549,29 @@ aXW
 uDV
 ecn
 uDV
-aIU
+agb
+xUB
+xUB
+xUB
+hPR
+fbV
+hLD
+ojT
+qAM
+agb
+agb
+agb
+aga
 aaa
-sxG
-eiH
-itl
-iKY
-eMO
-ahI
-ahI
-aiN
-aiO
-hZc
-aiO
-uhF
-vtg
-xEd
-hoi
-aiN
-ahI
-ahI
-ahI
 aaa
-aFx
+afZ
+aaa
+afZ
+afZ
+afZ
+afZ
+afZ
+aIA
 cVV
 cVV
 cVV
@@ -43777,28 +45806,28 @@ fFt
 vgm
 uSq
 bkB
-aIU
+agb
+tKT
+wSj
+nBh
+agG
+agG
+rpz
+tKT
+tKT
+ovq
+vad
+vDT
+aga
 afZ
-sxG
-saj
-xwK
-xwK
-bXZ
-ahI
-ahI
-aiO
-aiO
-aiO
-aiO
-iYN
-aiO
-aiO
-iYN
-aiO
-ahI
-ahI
-ahI
 afZ
+afZ
+afZ
+afZ
+aIA
+aIA
+aIA
+aIA
 aIA
 aIA
 aIA
@@ -44034,46 +46063,46 @@ vUd
 xen
 hsQ
 jEB
-aIU
+agb
+agb
+dcM
+agb
+agb
+fUB
+nrN
+dfw
+bXt
+agb
+veg
+agb
 aaa
-sxG
-jHG
-xwK
-xwK
-frz
-ahI
-aiy
-aiO
-ajk
-ajk
-ajk
-wui
-ajk
-ajk
-pXC
-aiO
-anx
-ahI
-ahI
 aaa
-aFx
+aaa
+afZ
+aaa
+afZ
+aIA
+aIg
+aIg
+fmR
+gCM
 aaC
-aaC
-aFx
-aFx
-aFx
-aFx
+aJM
+muC
+fCj
+asN
+wJD
 aIA
 aIA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 yib
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -44290,32 +46319,32 @@ iOO
 tps
 cza
 ygE
-cqz
-aIU
-aaa
-sxG
-cKR
-xwK
-huu
-wHe
-ahI
-ahI
-aiO
-ajk
-aiO
-ahI
-avF
-ahI
-aiO
-pXC
-aiO
-ahI
-ahI
-ahI
-aaa
-aFx
+xVm
+xVm
+xVm
+ppH
+tEY
+fSy
+fSy
+fSy
+fSy
+fSy
+fSy
+fSy
+fSy
+aln
+kIY
+kIY
+kIY
+aln
+aln
+aIA
+aIg
+rZz
+fmR
+wvU
 aFk
-aJM
+akb
 aVU
 aZM
 aaf
@@ -44547,36 +46576,36 @@ xRq
 nfl
 nzQ
 bYL
-jRo
-aIU
-aaa
-sxG
-sjD
-xwK
-gPS
-sxG
-ahI
-ahI
-hzq
-ajk
-aiO
-aKr
-fTG
-pOR
-aiO
-pXC
-aiO
-aNS
-ahI
-ahI
-aaa
-aFx
+ccu
+ccu
+fjS
+hcm
+nlA
+fSy
+wsz
+wsz
+fir
+fir
+fir
+fir
+fSy
+mMg
+wuL
+uMV
+bkZ
+iOH
+sHf
+aIA
+nTV
+rVo
+aIg
+fMi
 tbC
 akb
 aHD
-aGg
-aIg
-aIg
+gNw
+gNw
+gNw
 aKg
 aIA
 aaa
@@ -44802,39 +46831,39 @@ fuv
 kOy
 kGZ
 czH
-lsc
-bYL
+wim
+qoj
 jRo
 aIU
-aaa
-sxG
-kxD
-ndw
-cWb
-xoc
-lKN
-ahI
-aiO
-ajl
-aiO
-ahI
-aGK
-ahI
-aiO
-wui
-aiO
-xJB
-ahI
-ahI
-aaa
-aFx
+gul
+hGh
+iJB
+bni
+oGV
+rXU
+xfx
+xfx
+xfc
+gEQ
+lvB
+mMg
+brU
+pAU
+xKe
+mpx
+gny
+aIA
+aIg
+ayh
+sVO
+tnI
 tsB
 akb
 aeI
-aJH
-aIg
-aIg
-aIg
+nbM
+nbM
+nbM
+dCk
 aIA
 aaa
 aaa
@@ -45059,39 +47088,39 @@ jad
 osU
 wHQ
 czH
-mTa
-vgR
+wim
+qoj
 hWE
-aIU
-aaa
-sxG
-mwD
-lmn
-hFU
-myk
-oZE
-ahI
-jYi
-ajk
-lFe
-ahI
-ahI
-ahI
-dZk
-pXC
-aiO
-kTr
-ahI
-ahI
-aaa
-aFx
-vfo
-cXW
-aFx
-aFx
-aFx
-aFx
+bbh
+qEF
+fwn
+nlA
+fSy
+oNP
+pQW
+iUM
+iUM
+fGL
+nRO
+fSy
+mMg
+mMg
+efW
+mMg
+mMg
+mMg
 aIA
+aIg
+aIg
+fmR
+gCM
+vfo
+akb
+aHD
+gNw
+gNw
+gNw
+gNw
 aIA
 aaa
 aaa
@@ -45315,40 +47344,40 @@ fQh
 cvY
 kOy
 vbt
-nfl
-nzQ
-bYL
-lNl
-aIU
-sGo
-sxG
-tjp
-waV
-jFc
-myk
-jHE
-ahI
-aiO
-ajk
-ajk
-ajk
-ajk
-dEW
-bjS
-hhf
-aiO
-aiz
-ahI
-ahI
-aaa
-aFx
+czH
+wim
+qoj
+hWE
+bbh
+uRz
+fwn
+nlA
+fSy
+gDd
+wjO
+qAq
+qAq
+eLB
+eik
+fSy
+mMg
+iin
+oiP
+mMg
+mMg
+mMg
+aIA
+aIA
+aIA
+aIA
+aIA
 aNU
 akb
-aVU
-aDf
-aAU
-aAU
-asN
+ikK
+nbM
+nbM
+tTv
+umZ
 aIA
 aaa
 aaa
@@ -45558,7 +47587,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -45574,38 +47603,38 @@ osU
 ubg
 bvv
 rLg
-bYL
+qoj
 ffR
 aIU
-aaa
-sxG
-scr
-koI
-fga
-myk
-oZE
-ahI
-aiN
-aiO
-aiO
-aiO
-asS
-lKa
-aiO
-aiO
-aiN
-ahI
-ahI
-ahI
-aaa
+oJv
+fwn
+nlA
+fSy
+kmZ
+nMx
+tfc
+tfc
+shE
+con
+fSy
+kKI
+oFE
+oFE
+vWO
+fLO
+mMg
+mMg
+fOx
+wrg
+qgd
 aFx
 iwy
 akb
-aVS
-aZd
-aIg
-aIg
-aBy
+aHD
+gNw
+gNw
+gNw
+aKg
 aIA
 aaa
 aaa
@@ -45829,40 +47858,40 @@ xBA
 qhV
 kkN
 uFn
-wim
-kGZ
-aLH
+pPz
+gMh
+wUf
+gtk
+gtk
+tCf
+iQf
 nlA
-aIU
-afZ
-sxG
-sxG
-sxG
-hZx
-sxG
-rzm
-agD
-agD
-agD
-akR
-akR
-akR
-azy
-akR
-akR
-akR
-akR
-akR
-akR
-afZ
+fSy
+fSy
+fSy
+fSy
+fSy
+fSy
+fSy
+fSy
+uMm
+rgc
+oFE
+mQL
+hqW
+uTD
+uxN
+uxN
+nrV
+odR
 aFx
 aEZ
 avC
-aKO
-arQ
-aAS
-aIg
-aIg
+ikK
+nbM
+oSd
+nbM
+rrd
 aIA
 aaa
 aaa
@@ -46089,37 +48118,37 @@ aLH
 prX
 jYQ
 gtm
-nlA
+lFg
+mML
+ulK
+mML
+iXr
 aIU
-aaa
-agD
-jZS
-evK
 rpf
-dIh
-gxw
-jai
-smg
-akz
-akR
-alt
-pyV
-qfi
-alu
-gru
-rYq
-anY
-aoM
-akR
-aaa
+xjJ
+mgV
+fZb
+jOG
+uMm
+uMm
+gDS
+aUy
+oFE
+aEN
+dxt
+mMg
+mMg
+mMg
+sae
+oCt
 aFx
 aEZ
-cXW
-aFx
-aFx
-aFx
-aFx
-aIA
+akb
+aHD
+gNw
+gNw
+gNw
+gNw
 aIA
 aaa
 aaa
@@ -46348,35 +48377,35 @@ ygJ
 nFG
 ecP
 aIU
-aaa
-agD
-qwB
-ahg
-ahg
-saZ
-ahg
-ahg
-ahg
-wYb
-hRN
-fHm
-alI
-waH
-avB
-anz
-anY
-anY
-aoN
-akR
-aaa
+cHK
+aIU
+aIU
+aIU
+ipS
+uMm
+uMm
+fZb
+xyT
+bay
+iln
+iln
+kQm
+kQm
+kQm
+kQm
+kQm
+kQm
+siI
+iAx
+qdq
 aFx
 jNz
 akb
-aVU
-awY
-aAU
-aAU
-asN
+ikK
+nbM
+nbM
+nbM
+gCV
 aIA
 aaa
 aaa
@@ -46602,43 +48631,43 @@ aaq
 jpq
 slF
 wni
-wim
+uXQ
 hWV
 aIU
-aaa
-agD
-vxt
-ahg
-ahg
-cDf
-pzU
-oGd
-fXO
-pzU
-oSZ
-vku
-wWQ
-ntm
-rjd
-anz
-anZ
-anY
-dCE
-akR
-aaa
+fvM
+ctd
+oOB
+abv
+dUY
+bay
+uMm
+fZb
+bay
+gDS
+iln
+bAb
+xPZ
+qdF
+mNU
+cbO
+cIV
+cbO
+jBB
+aqL
+pWe
 aFx
 asa
 akb
 axF
-aEY
-aIg
-aIg
-aKG
+gNw
+gNw
+gNw
+aKg
 aIA
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -46838,7 +48867,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -46862,37 +48891,37 @@ cuJ
 enj
 cBT
 aIU
-aaa
-agD
-ahh
-ahK
-aie
-aiC
-ahh
-lRz
-ixt
-qYD
-akR
-alv
-rrp
-amL
-hkY
-amg
-nau
-apa
-aoP
-akR
-aaa
+xXT
+aTp
+aen
+abv
+bPZ
+uMm
+bay
+nUY
+uMm
+bay
+hFH
+bAb
+xPZ
+buF
+cnb
+ddZ
+gZM
+iQH
+buu
+cfr
+ojn
 aFx
 aEZ
 akb
 atz
-aMi
+aIg
 aIg
 aIg
 aAS
 aIA
-peJ
+aaa
 aaa
 aaa
 aaa
@@ -47100,7 +49129,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -47119,27 +49148,27 @@ odK
 obD
 aIU
 aIU
-afZ
-agD
-tWJ
-vKa
-vKa
-vPd
-mZW
-agD
-agD
-agD
-akR
-akR
-akR
-akR
-akR
-akR
-akR
-akR
-akR
-akR
-afZ
+emo
+uTM
+wOL
+abv
+ssC
+bay
+bay
+fZb
+mqr
+uMm
+iln
+bAb
+xPZ
+cIc
+bZs
+cbO
+uJz
+cbO
+fVt
+xoB
+ngM
 aFx
 vby
 xUM
@@ -47375,28 +49404,28 @@ azF
 awd
 rlh
 pgB
+rIQ
+tPI
+gGm
+tsn
 abv
-aaa
-afZ
-ahj
-afZ
-afZ
-mFX
-ahj
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-aaa
+fZb
+fZb
+fZb
+fZb
+bay
+uMm
+iln
+iln
+kQm
+kQm
+kQm
+kQm
+kQm
+kQm
+khh
+gny
+hpP
 aFx
 ksu
 aXk
@@ -47632,28 +49661,28 @@ eHc
 kJq
 kCf
 unQ
-abv
-aaa
-afZ
-aiQ
-aaa
-aaa
-mFX
-aiQ
-afZ
-afZ
-afZ
-aaa
-aaa
-aaa
-aaa
-afZ
-aaa
-aaa
-aaa
-aaa
-afZ
-aaa
+gtx
+rZU
+jaE
+cmG
+wTm
+gDS
+uMm
+gDS
+uMm
+bay
+bay
+qAU
+gDS
+bhW
+lhx
+azJ
+mlb
+mlb
+gmP
+oFE
+ihx
+mHc
 aFx
 nyp
 jre
@@ -47889,31 +49918,31 @@ wLT
 mXJ
 kew
 pQo
+qPK
+sqk
+jfB
+olX
 abv
-afZ
-afZ
-ahl
-afZ
-afZ
-mFX
-ahl
-afZ
-afZ
-afZ
-aaa
-aaa
-aaa
-aaa
-afZ
-aaa
-aaa
-aaa
-aaa
-afZ
-afZ
+tbp
+cuM
+bay
+bay
+gDS
+uMm
+bay
+iVz
+qAU
+qAU
+gDS
+gDS
+cTN
+bay
+oFE
+oPX
+mHc
 aFx
 ozt
-avN
+akb
 aGi
 arl
 aDt
@@ -47978,9 +50007,9 @@ aaa
 aaa
 aaa
 aaa
+oZD
 aaa
-aaa
-aaa
+oZD
 aaa
 aaa
 aaa
@@ -48147,27 +50176,27 @@ abv
 abv
 vqX
 abv
-abv
-agE
-ahm
-agE
-agE
-imB
-aiR
-agE
-afZ
-afZ
-afZ
-afZ
-aiD
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-afZ
-aEV
+aJb
+aJb
+aJb
+aJb
+aJb
+aJb
+nUY
+aJb
+aJb
+weB
+mqr
+bay
+bay
+uMm
+bay
+bay
+bay
+afL
+oFE
+oPX
+mHc
 aFx
 mPD
 ahC
@@ -48177,7 +50206,23 @@ aDt
 aYX
 ain
 aDt
-afP
+fxf
+vff
+vff
+vff
+fxf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+yib
 aaa
 aaa
 aaa
@@ -48219,25 +50264,9 @@ aaa
 aaa
 aaa
 aaa
+bAb
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bAb
 aaa
 aaa
 aaa
@@ -48404,27 +50433,27 @@ abv
 biX
 cbG
 loF
-agb
+aJb
 tVi
 tsw
-hPR
-fbV
-hLD
-xUB
-xUB
-agb
+bPP
+uAR
+dCR
+aRj
+dyC
+aJb
 aiF
 aiF
 aiF
 aEV
 aEV
 nUY
-nUY
 aEV
 aEV
 aEV
 aEV
 aEV
+dut
 aFx
 ckY
 aFx
@@ -48434,7 +50463,11 @@ aDt
 msF
 wXz
 aDt
-afP
+fxf
+kJS
+aWb
+vhh
+vff
 aaa
 aaa
 aaa
@@ -48488,13 +50521,9 @@ aaa
 aaa
 aaa
 aaa
+bAb
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bAb
 aaa
 aaa
 aaa
@@ -48661,15 +50690,15 @@ abv
 rAw
 hZd
 xFk
-omG
+aJb
 uTT
 nhy
-agG
-agG
-rpz
+aRj
+jWt
+xRp
 hmB
 atQ
-agb
+aJb
 ayu
 ayu
 ayu
@@ -48691,7 +50720,11 @@ aDt
 aDt
 kto
 aDt
-afP
+fxf
+rbI
+jVd
+dRm
+vff
 aaa
 aaa
 aaa
@@ -48744,15 +50777,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bAb
+xOT
+jdG
+xOT
+bAb
 aaa
 aaa
 aaa
@@ -48918,15 +50947,15 @@ abv
 aeb
 tNR
 aJP
-agb
+aJb
 axX
 uUt
-hGg
+aRj
 vxJ
-svp
+aRj
 aSm
 eFV
-agb
+aJb
 tYY
 aec
 eIk
@@ -48944,19 +50973,15 @@ mzF
 mff
 jNp
 tdr
-bnk
+tdr
 iyp
 iDQ
-aqS
-aqT
-aaa
-aaa
-aaa
-yib
-aaa
-aaa
-aaa
-aaa
+ruK
+fhp
+fhp
+rve
+hOv
+vff
 aaa
 aaa
 aaa
@@ -49008,9 +51033,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bAb
+jdG
+xOT
+jFz
+xOT
+jdG
+bAb
 aaa
 aaa
 aaa
@@ -49175,15 +51204,15 @@ abv
 abv
 bWE
 abv
-agb
-agb
-agb
-agb
-agb
-agb
-agb
-agb
-agb
+aJb
+ado
+xDE
+ado
+aJb
+ado
+vHb
+ado
+aJb
 pdV
 pdV
 pdV
@@ -49202,75 +51231,75 @@ aXI
 aXI
 aXI
 aXI
-eHm
-aqR
-aqS
-aqT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wUL
+ugj
+bPh
+pgW
+vhe
+vhe
+dyA
+fxf
+bAb
+bAb
+oZD
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+oZD
+bAb
+bAb
+xOT
+xOT
+paw
+hir
+pMc
+xOT
+xOT
+bAb
+bAb
+oZD
 aaa
 aaa
 aaa
@@ -49432,13 +51461,13 @@ ber
 vgQ
 oAi
 xIO
+nNX
 xzE
-lAZ
-xzE
-xzE
-xzE
+goc
 xzE
 xzE
+xzE
+vVu
 xzE
 ePW
 teQ
@@ -49459,10 +51488,14 @@ ayQ
 wJN
 oZo
 aXI
-gkg
-aqR
-aqS
-aqT
+bBI
+aEV
+bPh
+fXY
+kvw
+kvw
+lne
+kvw
 aaa
 aaa
 aaa
@@ -49514,17 +51547,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jiO
+hru
+hru
+beu
+iJK
+uSH
+vrA
 aaa
 aaa
 aaa
@@ -49691,11 +51720,11 @@ hPw
 cnP
 tGY
 tGY
-tGY
+kur
 bxt
 tGY
 tGY
-tGY
+byj
 tGY
 rgb
 tGY
@@ -49718,73 +51747,73 @@ rVf
 svj
 fIz
 hra
-aqS
-aqT
-aqT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bPh
+fxf
+fxf
+fxf
+fxf
+fxf
+bAb
+bAb
+oZD
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+bAb
+oZD
+bAb
+bAb
+xOT
+xOT
+fgu
+vzX
+efz
+xOT
+xOT
+bAb
+bAb
+oZD
 aaa
 aaa
 aaa
@@ -50032,13 +52061,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bAb
+jdG
+xOT
+vUm
+xOT
+jdG
+bAb
 aaa
 aaa
 aaa
@@ -50200,17 +52229,17 @@ aaY
 sPc
 aaY
 aaY
-aee
+bIh
 ebZ
 ikD
 lnY
-aee
+bIh
 tAE
-aee
-ado
-vyf
-ado
-aJb
+oUk
+oUk
+oUk
+oUk
+oUk
 aHp
 pdV
 gbs
@@ -50290,11 +52319,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bAb
+xOT
+jdG
+xOT
+bAb
 aaa
 aaa
 aaa
@@ -50457,18 +52486,18 @@ akd
 acj
 aGj
 aum
-aee
+bIh
 afd
 bfV
 dro
 ckw
 nmn
-aee
+oUk
 pMm
-aRj
+wkK
 pEI
 kXR
-ado
+oUk
 teQ
 xye
 eIk
@@ -50548,9 +52577,9 @@ aaa
 aaa
 aaa
 aaa
+bAb
 aaa
-aaa
-aaa
+bAb
 aaa
 aaa
 aaa
@@ -50722,8 +52751,8 @@ aeh
 lUu
 nri
 fMs
-kdU
-aRj
+ucC
+ucC
 qtv
 xQq
 yiJ
@@ -50805,9 +52834,9 @@ aaa
 aaa
 aaa
 aaa
+bAb
 aaa
-aaa
-aaa
+bAb
 aaa
 aaa
 aaa
@@ -50971,18 +53000,18 @@ abU
 abU
 uhs
 abU
-aee
+bIh
 gYA
 tvj
 tsx
 suT
 jFm
-aee
+oUk
 syY
 bUi
-bPP
+dcL
 jJw
-ado
+oUk
 teQ
 xye
 eIk
@@ -51062,9 +53091,9 @@ aaa
 aaa
 aaa
 aaa
+oZD
 aaa
-aaa
-aaa
+oZD
 aaa
 aaa
 aaa
@@ -51228,18 +53257,18 @@ abU
 hdy
 acm
 abT
-aee
+bIh
 aeY
 oPN
 aeY
 aee
-aee
-aee
-aJb
-aJb
-aJb
-aJb
-aJb
+bIh
+oUk
+oUk
+oUk
+oUk
+oUk
+oUk
 cbo
 xye
 eIk
@@ -51474,7 +53503,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -51523,7 +53552,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -51978,7 +54007,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -53839,7 +55868,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -54349,7 +56378,7 @@ aqT
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -54581,7 +56610,7 @@ aHn
 ycc
 aiv
 aiv
-pmn
+kVM
 xye
 uFj
 alS
@@ -56919,7 +58948,7 @@ aqT
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -58148,7 +60177,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -58170,8 +60199,8 @@ qxJ
 arK
 oRy
 aaB
-aaB
-aaB
+xji
+xji
 aaB
 oQO
 pxa
@@ -58926,7 +60955,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -59236,7 +61265,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -60745,7 +62774,7 @@ pcT
 aaB
 lsJ
 pxa
-ppo
+bas
 ajd
 aDd
 aVg
@@ -61748,7 +63777,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -62266,7 +64295,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -62571,7 +64600,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -63602,7 +65631,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -64111,7 +66140,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -64590,7 +66619,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -65131,7 +67160,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -65909,7 +67938,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -66142,7 +68171,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -66409,7 +68438,7 @@ aaa
 aaa
 aaa
 aaa
-yib
+aaa
 aaa
 aaa
 aaa
@@ -66641,7 +68670,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -67427,6 +69456,7 @@ aaa
 aaa
 aaa
 aaa
+yib
 aaa
 aaa
 aaa
@@ -67440,8 +69470,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+yib
 aaa
 aaa
 aaa

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -7532,6 +7532,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "daQ" = (
@@ -11964,6 +11967,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
 "iTE" = (
@@ -13504,6 +13510,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "kHl" = (
@@ -15916,6 +15925,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "oll" = (
@@ -23840,6 +23852,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
 "yib" = (

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -1044,6 +1044,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "ahg" = (
@@ -1806,6 +1807,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
 "akt" = (
@@ -2099,7 +2101,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "alI" = (
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "alJ" = (
 /turf/closed/wall,
@@ -2140,6 +2142,7 @@
 	},
 /obj/effect/landmark/start/head_of_personnel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/head_of_personnel)
 "ama" = (
@@ -2301,6 +2304,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "amV" = (
@@ -2498,6 +2502,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/disks_plantgene,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aoj" = (
@@ -3149,6 +3154,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/food/snacks/dough,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "ary" = (
@@ -3192,6 +3198,7 @@
 /area/crew_quarters/toilet)
 "arK" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "arL" = (
@@ -3209,6 +3216,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "arR" = (
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "arT" = (
@@ -3538,6 +3546,7 @@
 /obj/item/flashlight/lamp{
 	pixel_y = 10
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "ave" = (
@@ -3585,7 +3594,7 @@
 /area/security/warden)
 "avB" = (
 /obj/effect/landmark/start/cyborg,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "avC" = (
 /obj/effect/landmark/start/scientist,
@@ -3673,6 +3682,7 @@
 	},
 /obj/item/beacon,
 /obj/effect/spawner/xmastree/rdrod,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "awU" = (
@@ -4202,6 +4212,7 @@
 /area/science/robotics/lab)
 "aDp" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aDt" = (
@@ -4454,6 +4465,7 @@
 "aHf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "aHh" = (
@@ -4917,6 +4929,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "aLG" = (
@@ -5000,6 +5013,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "aMJ" = (
@@ -5118,6 +5132,7 @@
 "aOC" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aOH" = (
@@ -5535,6 +5550,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aVo" = (
@@ -5594,6 +5610,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/library)
 "aWu" = (
@@ -6231,6 +6248,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bEI" = (
@@ -6611,6 +6629,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cat" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "caS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -6722,6 +6755,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cfr" = (
@@ -6889,6 +6923,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/fore)
+"crA" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "crV" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/blue,
@@ -7157,12 +7198,30 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
+/area/maintenance/aft)
+"cEl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
 /area/maintenance/aft)
 "cEO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "cGi" = (
@@ -7233,7 +7292,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "cLw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -7370,7 +7429,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cWb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7460,6 +7519,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/navbeacon/wayfinding/bridge,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "dcm" = (
@@ -7531,6 +7591,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
 "ddZ" = (
@@ -7646,6 +7707,22 @@
 /obj/item/pen/red,
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"drY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dsm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -7727,6 +7804,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hos)
+"dul" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/science/storage)
 "dut" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Mixing Lab";
@@ -8197,7 +8282,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ecP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
@@ -8263,6 +8348,13 @@
 /area/crew_quarters/heads/head_of_personnel)
 "efW" = (
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "egg" = (
@@ -8322,7 +8414,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "ejO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -8613,6 +8705,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"eBE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "eBI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8810,6 +8921,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"eNZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "ePH" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -8852,6 +8970,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "eUp" = (
@@ -9474,6 +9593,12 @@
 /obj/item/transfer_valve{
 	pixel_x = 5
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "fQh" = (
@@ -9903,6 +10028,7 @@
 /area/engine/atmos)
 "gtx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "gtV" = (
@@ -10662,6 +10788,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/holopad/emergency/medical,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical)
 "hzq" = (
@@ -10923,6 +11050,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "hRI" = (
@@ -11104,6 +11232,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "hZq" = (
@@ -11254,6 +11383,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "ihx" = (
@@ -11359,6 +11489,10 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "inK" = (
@@ -11425,7 +11559,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 1
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "itx" = (
 /obj/machinery/holopad,
@@ -11519,6 +11653,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "iFm" = (
@@ -11614,7 +11751,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "iNj" = (
 /obj/structure/closet/secure_closet/head_of_personnel,
@@ -11731,6 +11868,7 @@
 /area/science/storage)
 "iVz" = (
 /mob/living/simple_animal/hostile/cockroach,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "iWL" = (
@@ -11806,6 +11944,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iZX" = (
@@ -11860,6 +11999,22 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"jcF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jdE" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -11953,6 +12108,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
 "jiO" = (
@@ -11997,6 +12153,32 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"jnI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jof" = (
 /obj/machinery/computer/card,
 /turf/open/floor/plasteel/grimy,
@@ -12073,6 +12255,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jrv" = (
@@ -12091,7 +12274,7 @@
 /area/hallway/secondary/command)
 "jtK" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/science/misc_lab)
 "jtN" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -12229,6 +12412,14 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/machinery/button/ignition/incinerator/toxmix{
+	pixel_x = -7;
+	pixel_y = 25
+	},
+/obj/machinery/button/door/incinerator_vent_toxmix{
+	pixel_x = 7;
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "jDh" = (
@@ -12331,14 +12522,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/comms)
 "jHG" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "jJw" = (
 /obj/structure/rack,
@@ -12517,6 +12708,7 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "jWH" = (
@@ -12586,6 +12778,9 @@
 /area/engine/atmos)
 "jZr" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "jZS" = (
@@ -12902,6 +13097,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "krW" = (
@@ -13032,7 +13228,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "kyK" = (
 /obj/structure/disposalpipe/segment,
@@ -13229,6 +13425,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"kLI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "kNw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -13511,7 +13730,7 @@
 	id = "toxinsdriver";
 	name = "Toxins Launcher Bay Door"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
 /area/science/misc_lab)
 "lnY" = (
 /obj/structure/cable,
@@ -13730,8 +13949,13 @@
 /obj/item/radio/intercom{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/comms)
+"lLJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lMo" = (
 /obj/structure/ladder{
 	name = "service ladder"
@@ -13814,6 +14038,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad/emergency/medical,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "lRn" = (
@@ -14067,6 +14292,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"mtn" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "muC" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
@@ -14133,7 +14367,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "mxd" = (
 /obj/effect/turf_decal/tile/blue{
@@ -14185,6 +14419,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "mzS" = (
@@ -14219,6 +14454,7 @@
 	height = 1;
 	id = "Vault"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/vault,
 /area/ai_monitored/nuke_storage)
 "mFn" = (
@@ -14241,6 +14477,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -14508,6 +14748,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"mVD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "mVH" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -14827,6 +15077,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/main)
 "nrV" = (
@@ -14847,7 +15098,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ntO" = (
 /obj/machinery/door/airlock/medical{
@@ -14947,6 +15198,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "nyp" = (
@@ -15077,6 +15329,7 @@
 /obj/machinery/firealarm{
 	pixel_y = -26
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "nIa" = (
@@ -15397,8 +15650,16 @@
 	},
 /obj/item/analyzer,
 /obj/item/pipe_dispenser,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"oeP" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "oeW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15597,6 +15858,13 @@
 /obj/machinery/navbeacon/wayfinding/hydro,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"oua" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ouJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 2"
@@ -15624,6 +15892,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "oyn" = (
@@ -15704,6 +15973,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"oCi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "oCt" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer{
@@ -15724,6 +16006,10 @@
 	},
 /obj/item/assembly/timer,
 /obj/item/storage/firstaid/toxin,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "oCD" = (
@@ -15736,6 +16022,10 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/brig)
+"oDh" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "oDk" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -15955,6 +16245,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"oRI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "oSd" = (
 /mob/living/simple_animal/slime,
 /obj/structure/window/reinforced{
@@ -15962,6 +16258,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"oSC" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "oSZ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "MiniSat Upload";
@@ -16109,7 +16409,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/comms)
 "oZP" = (
 /turf/closed/wall,
@@ -16281,6 +16581,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "phr" = (
@@ -16303,6 +16606,7 @@
 /area/library)
 "phU" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "pia" = (
@@ -16406,6 +16710,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pmk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pmn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -16808,6 +17129,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "pLk" = (
@@ -16909,6 +17231,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"pQG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pQW" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/stripes/line{
@@ -17003,6 +17339,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"pZN" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "qbR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -17072,6 +17418,13 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "qhM" = (
@@ -17157,6 +17510,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "qoj" = (
@@ -17313,6 +17667,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "qDl" = (
@@ -17730,7 +18085,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rkv" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -17917,6 +18272,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "rve" = (
@@ -17929,6 +18287,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "rvi" = (
@@ -17936,6 +18296,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"rvx" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rxn" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -17960,6 +18324,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "rzm" = (
@@ -17979,7 +18345,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/comms)
 "rzD" = (
 /obj/item/radio/intercom{
@@ -18151,6 +18517,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"rJz" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rJT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18183,11 +18556,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rLq" = (
-/obj/machinery/computer/prisoner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/computer/prisoner/management{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
@@ -18287,6 +18660,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"rRW" = (
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "rRX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18424,7 +18800,7 @@
 /obj/machinery/airalarm/server{
 	pixel_y = 24
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "saZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -18499,7 +18875,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "sjW" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -18777,6 +19153,29 @@
 	},
 /turf/open/floor/vault,
 /area/ai_monitored/nuke_storage)
+"sDd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sDg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm{
@@ -18975,6 +19374,22 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"sXC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "sYG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -19133,6 +19548,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "thX" = (
@@ -19147,7 +19563,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/comms)
 "tkd" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -19353,6 +19769,17 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"tzt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "tAn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -19639,6 +20066,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/head_of_personnel)
+"tRS" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "tRW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20087,7 +20518,7 @@
 	},
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "uEl" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -20555,6 +20986,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
 "vgm" = (
@@ -20918,6 +21350,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/locker_room)
 "vHb" = (
@@ -21122,6 +21555,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vXR" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "vYj" = (
 /obj/machinery/light_switch{
 	dir = 9;
@@ -21180,7 +21622,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "waV" = (
 /obj/structure/cable{
@@ -21384,6 +21826,12 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -21732,6 +22180,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wJN" = (
@@ -21926,6 +22375,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/observer_start,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wUL" = (
@@ -21948,7 +22398,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "wXz" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -22128,6 +22578,7 @@
 "xaL" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad/emergency/science,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "xct" = (
@@ -22156,6 +22607,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xdm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "xen" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
@@ -22246,7 +22711,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/comms)
 "xox" = (
 /obj/machinery/vending/cola/random,
@@ -22468,6 +22933,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "xyT" = (
@@ -22529,6 +22997,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"xEL" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xFk" = (
 /obj/machinery/navbeacon/wayfinding/minisat_access_tcomms_ai,
 /obj/effect/turf_decal/stripes/line,
@@ -22621,6 +23093,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "xJB" = (
@@ -23098,6 +23571,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
 "yib" = (
@@ -45738,9 +46212,9 @@ aLt
 nIc
 agY
 aXW
-hru
-hru
-hru
+rRW
+rRW
+rRW
 agb
 rpS
 agE
@@ -45764,9 +46238,9 @@ aaa
 afZ
 afZ
 aIA
-hru
-hru
-hru
+rRW
+rRW
+rRW
 aIA
 aaa
 aaa
@@ -47038,7 +47512,7 @@ fir
 jRt
 fir
 fSy
-mMg
+crA
 wuL
 uMV
 bkZ
@@ -47295,7 +47769,7 @@ xfx
 xfc
 gEQ
 lvB
-mMg
+crA
 brU
 pAU
 xKe
@@ -47547,24 +48021,24 @@ nlA
 fSy
 oNP
 pQW
-iUM
+dul
 iUM
 fGL
 nRO
 fSy
 jZr
-mMg
+mtn
 efW
-mMg
-mMg
-mMg
+mtn
+mtn
+pZN
 aIA
 aIg
 slY
 fmR
 gCM
 vfo
-akb
+lLJ
 aHD
 gNw
 gNw
@@ -47794,12 +48268,12 @@ cvY
 kOy
 vbt
 czH
-wim
+pQG
 qoj
 hWE
 bbh
 uRz
-fwn
+pmk
 nlA
 fSy
 gDd
@@ -47814,7 +48288,7 @@ iin
 oiP
 mMg
 mMg
-mMg
+rJz
 aIA
 aIA
 aIA
@@ -48071,8 +48545,8 @@ oFE
 oFE
 vWO
 fLO
-mMg
-mMg
+oRI
+vXR
 fOx
 wrg
 qgd
@@ -48587,7 +49061,7 @@ aEN
 dxt
 mMg
 mMg
-mMg
+oDh
 sae
 oCt
 aFx
@@ -49088,7 +49562,7 @@ ctd
 oOB
 abv
 dUY
-bay
+xEL
 uMm
 fZb
 bay
@@ -49345,7 +49819,7 @@ aTp
 aen
 abv
 bPZ
-uMm
+tRS
 bay
 nUY
 uMm
@@ -51426,7 +51900,7 @@ tdr
 iyp
 iDQ
 ruK
-fhp
+tzt
 fhp
 rve
 hOv
@@ -52168,7 +52642,7 @@ bKh
 hPw
 cnP
 tGY
-tGY
+eBE
 kur
 bxt
 tGY
@@ -53201,7 +53675,7 @@ lUu
 nri
 fMs
 ucC
-ucC
+cat
 qtv
 xQq
 yiJ
@@ -53700,7 +54174,7 @@ aaa
 aaa
 aaa
 aRC
-wOP
+oeP
 qQq
 abU
 hdy
@@ -54472,7 +54946,7 @@ aaa
 aaa
 aRC
 aYD
-qQq
+drY
 abU
 eXD
 afb
@@ -54485,7 +54959,7 @@ agJ
 ahr
 ekx
 szx
-ajs
+oSC
 rNV
 axn
 akc
@@ -56032,7 +56506,7 @@ agJ
 agJ
 agJ
 atM
-kXd
+kLI
 eDf
 aPo
 aRt
@@ -56271,7 +56745,7 @@ aaa
 aRC
 aRC
 aYD
-qQq
+jcF
 abX
 acu
 acR
@@ -56563,7 +57037,7 @@ aqb
 dCm
 aqb
 aqb
-rDv
+eNZ
 pja
 aqS
 aqT
@@ -58350,7 +58824,7 @@ uDo
 anS
 vDg
 aok
-aPh
+xdm
 gDi
 aPh
 xBe
@@ -58583,7 +59057,7 @@ aaa
 aRC
 aRC
 aYD
-jeL
+oua
 xrY
 abY
 acy
@@ -58841,7 +59315,7 @@ aaa
 qss
 aYD
 cxK
-qQq
+drY
 abY
 acz
 aFi
@@ -59623,7 +60097,7 @@ qin
 vhS
 jgF
 oHT
-vhS
+mVD
 vhS
 wvY
 gzh
@@ -60417,7 +60891,7 @@ aLd
 abR
 apd
 gXD
-aqR
+rvx
 aDL
 aqS
 aqT
@@ -61187,7 +61661,7 @@ apd
 whn
 arG
 apd
-gkg
+sXC
 aqR
 aqR
 aqS
@@ -62708,7 +63182,7 @@ nRZ
 pcT
 aaB
 lsJ
-pxa
+sDd
 jtN
 ajd
 ajr
@@ -62720,7 +63194,7 @@ keN
 iNj
 ama
 eFj
-ykj
+jnI
 jtN
 apj
 cze
@@ -64014,7 +64488,7 @@ wYT
 lRn
 kdv
 oZP
-gkg
+cEl
 aaN
 aqS
 aqT
@@ -64785,7 +65259,7 @@ afl
 aWs
 aEp
 oZP
-pja
+oCi
 aqR
 aqT
 aqT

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -3268,6 +3268,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 32
+	},
+/obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "asb" = (
@@ -5456,6 +5460,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aUd" = (
@@ -19763,6 +19769,22 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"tfm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "tgn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -24007,7 +24029,7 @@
 "ylu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Bar Backroom";
-	req_access = "25";
+	req_access = null;
 	req_access_txt = "25"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50125,7 +50147,7 @@ buu
 cfr
 ojn
 aFx
-aEZ
+tfm
 akb
 atz
 aIg

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -319,6 +319,9 @@
 /area/medical/abandoned)
 "bu" = (
 /obj/structure/table/optable,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "bw" = (
@@ -1385,6 +1388,9 @@
 /area/maintenance/fore/upper)
 "em" = (
 /obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "en" = (
@@ -1762,6 +1768,9 @@
 "fl" = (
 /obj/machinery/chem_master{
 	pixel_x = -4
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
@@ -2607,6 +2616,9 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin{
 	pixel_x = 2
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
@@ -4840,6 +4852,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/security/prison/toilet)
 "mj" = (
@@ -5522,6 +5535,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
+"nH" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "nI" = (
 /turf/closed/wall,
 /area/hydroponics/garden/abandoned)
@@ -7297,7 +7318,7 @@
 "rx" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/hallway/primary/upper)
 "ry" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -10902,7 +10923,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light,
 /obj/machinery/button/door{
 	id = "QMLoaddoor";
 	layer = 4;
@@ -10940,13 +10960,6 @@
 	dir = 8;
 	id = "QMLoad"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"zN" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "zO" = (
@@ -11453,9 +11466,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
 "Be" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -11471,6 +11481,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -13010,8 +13023,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/light/small,
 /obj/structure/table,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "Fp" = (
@@ -13402,6 +13415,7 @@
 	dir = 8;
 	id = "QMLoad2"
 	},
+/obj/machinery/light,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "Gl" = (
@@ -13608,6 +13622,9 @@
 /area/quartermaster/storage)
 "Hv" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "Hw" = (
@@ -15332,6 +15349,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/pen,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/tcommsat/server/upper)
 "OI" = (
@@ -16121,6 +16139,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
 "Sd" = (
@@ -16167,7 +16188,7 @@
 /area/ai_monitored/storage/eva)
 "Sl" = (
 /obj/structure/grille,
-/turf/closed/wall/r_wall,
+/turf/open/transparent/openspace/airless,
 /area/space/nearstation)
 "Sm" = (
 /obj/structure/ladder/unbreakable{
@@ -16361,6 +16382,10 @@
 "Th" = (
 /obj/item/paper/guides/jobs/engi/solars,
 /obj/structure/table,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "Ti" = (
@@ -46156,7 +46181,7 @@ vN
 vN
 ya
 yH
-zM
+nH
 tv
 Bk
 Ca
@@ -46670,7 +46695,7 @@ wH
 xs
 yc
 yH
-zN
+wI
 tv
 Bm
 Cb

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -8740,11 +8740,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/solgov)
 "uL" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = -26
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Internal Affairs"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/solgov)
@@ -14976,6 +14977,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/engine/gravity_generator)
 "Mr" = (
@@ -16580,7 +16584,7 @@
 /area/maintenance/solars/starboard/aft)
 "Ti" = (
 /obj/machinery/door/window/eastleft{
-	name = "lieutenant's office";
+	name = "\improper SolGov Consulate";
 	req_access_txt = "90"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17883,6 +17887,10 @@
 	dir = 1
 	},
 /obj/machinery/telecomms/relay/preset/station,
+/obj/machinery/camera{
+	c_tag = "Engineering - Upper Comms Relay";
+	name = "engineering camera"
+	},
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server/upper)
 "YM" = (

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -15,6 +15,14 @@
 "ab" = (
 /turf/open/transparent/openspace/airless,
 /area/space)
+"af" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "ag" = (
 /obj/effect/turf_decal/trimline/white/corner,
 /turf/open/floor/engine/hull,
@@ -296,6 +304,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"bn" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "bq" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
@@ -443,6 +458,13 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
+"bK" = (
+/obj/structure/reflector/box/anchored{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "bL" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -649,6 +671,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/fore/upper)
 "cv" = (
@@ -730,6 +753,7 @@
 /area/lawoffice)
 "cD" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "cE" = (
@@ -756,9 +780,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
+"cH" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/aft/upper)
 "cI" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/brig_phys,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "cJ" = (
@@ -784,6 +814,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/maintenance/aft/upper)
 "cN" = (
@@ -1399,6 +1430,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -1744,6 +1777,8 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "fj" = (
@@ -1815,6 +1850,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "fr" = (
@@ -2698,6 +2734,7 @@
 	c_tag = "Security - Prison";
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hz" = (
@@ -3106,6 +3143,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "io" = (
@@ -3451,6 +3489,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/beacon,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iT" = (
@@ -3680,6 +3719,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "js" = (
@@ -3936,6 +3976,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "jU" = (
@@ -4422,6 +4463,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "lb" = (
@@ -4508,6 +4550,7 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -4960,6 +5003,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "mz" = (
@@ -5158,6 +5202,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -5477,6 +5522,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "nA" = (
@@ -5870,6 +5916,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "or" = (
@@ -7119,6 +7166,7 @@
 /area/security/checkpoint/auxiliary)
 "qZ" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "ra" = (
@@ -7259,10 +7307,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"rp" = (
-/obj/effect/turf_decal/trimline/white/corner,
-/turf/open/floor/engine/hull,
-/area/space)
 "rq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7314,7 +7358,7 @@
 	},
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "rx" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
@@ -7706,6 +7750,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/upper)
 "sm" = (
@@ -8669,9 +8714,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/lone,
 /area/crew_quarters/bar/atrium)
 "uI" = (
 /obj/structure/table/wood/fancy,
@@ -8679,17 +8722,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/lone,
 /area/crew_quarters/bar/atrium)
 "uJ" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/lone,
 /area/crew_quarters/bar/atrium)
 "uK" = (
 /obj/structure/closet/secure_closet/lieutenant,
@@ -8838,6 +8877,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "vb" = (
@@ -9023,6 +9063,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "vt" = (
@@ -9099,9 +9140,7 @@
 "vD" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/lone,
 /area/crew_quarters/bar/atrium)
 "vE" = (
 /obj/structure/grille/broken,
@@ -9444,14 +9483,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar/atrium)
 "ws" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/lone,
 /area/crew_quarters/bar/atrium)
 "wt" = (
 /obj/structure/lattice,
@@ -9541,6 +9579,7 @@
 "wE" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wF" = (
@@ -9602,6 +9641,7 @@
 	pixel_y = 30
 	},
 /obj/item/kirbyplants/random,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wN" = (
@@ -9640,6 +9680,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/maintenance/aft/upper)
 "wT" = (
@@ -9711,9 +9752,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/lone,
 /area/crew_quarters/bar/atrium)
 "xc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -9930,6 +9969,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
 "xB" = (
@@ -10069,6 +10109,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "xR" = (
@@ -10554,6 +10595,8 @@
 "yP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "yQ" = (
@@ -10801,6 +10844,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "zv" = (
@@ -11058,6 +11102,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/theatre)
 "Ad" = (
@@ -11091,6 +11136,7 @@
 /area/crew_quarters/fitness)
 "Ai" = (
 /obj/machinery/vending/cola/random,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "Aj" = (
@@ -11643,6 +11689,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
 "Bz" = (
@@ -11657,6 +11704,7 @@
 /obj/machinery/firealarm{
 	pixel_y = -26
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/engine/gravity_generator)
 "BA" = (
@@ -11681,6 +11729,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
 "BD" = (
@@ -11834,6 +11883,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "BY" = (
@@ -12181,6 +12231,7 @@
 "CR" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "CS" = (
@@ -12259,6 +12310,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
 "Da" = (
@@ -12316,6 +12368,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/theatre)
 "De" = (
@@ -12355,8 +12408,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/interior,
 /area/quartermaster/miningdock)
+"Dn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "Do" = (
 /obj/structure/window/reinforced/spawner/west,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "Dp" = (
@@ -12740,6 +12801,20 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/dorms)
+"Ew" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "Ey" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12821,6 +12896,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -12886,6 +12962,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
 "ER" = (
@@ -12966,6 +13043,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/crew_quarters/dorms)
+"Ff" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "Fg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -13080,6 +13162,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
 "Fx" = (
@@ -13326,6 +13409,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/aft/upper)
 "FT" = (
@@ -13524,9 +13608,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/crew_quarters/bar/atrium)
-"GO" = (
-/turf/open/floor/engine/hull,
-/area/space)
 "GQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -13952,6 +14033,17 @@
 	},
 /turf/open/transparent/openspace/airless,
 /area/solar/starboard/aft)
+"IJ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/transparent/openspace,
+/area/engine/engineering)
 "IL" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -13963,10 +14055,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
-"IN" = (
-/obj/effect/turf_decal/trimline/white/line,
-/turf/open/floor/engine/hull,
-/area/space)
 "IO" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14012,6 +14100,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"Jf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/hydroponics/garden/abandoned)
 "Jl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14085,6 +14179,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "Jy" = (
@@ -14151,6 +14246,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"JE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/upper)
 "JF" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Storage";
@@ -14201,6 +14310,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "JM" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/central)
 "JN" = (
@@ -14284,6 +14395,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"Kf" = (
+/obj/effect/turf_decal/trimline/white/corner,
+/obj/effect/turf_decal/trimline/white/corner{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "Kg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14326,12 +14444,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore/upper)
-"Kp" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 10
-	},
-/turf/open/floor/engine/hull,
-/area/space)
 "Ks" = (
 /obj/structure/curtain/cloth,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -14367,6 +14479,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"KB" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
+"KD" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "KE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14473,6 +14594,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"Lc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/aft/upper)
 "Lf" = (
 /obj/machinery/computer/card/minor/ce,
 /obj/machinery/light{
@@ -14574,6 +14700,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"Ls" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/fore/upper)
 "Lt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenic Lounge"
@@ -14719,6 +14850,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "LO" = (
@@ -14754,6 +14886,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/maintenance/central)
+"LT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/maintenance/fore/upper)
 "LU" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -14903,6 +15040,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/engine/engineering)
+"MA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/aft/upper)
 "MD" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/toilet)
@@ -15068,6 +15215,12 @@
 	},
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/engine/gravity_generator)
+"Nm" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "No" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
@@ -15197,12 +15350,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"NR" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/engine/hull,
-/area/space)
 "NT" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -15389,6 +15536,16 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"OS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/fore/upper)
 "OU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Cargo";
@@ -15680,6 +15837,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/central)
+"PO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/maintenance/aft/upper)
 "PT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -15806,6 +15979,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"Qp" = (
+/obj/machinery/field/generator,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "Qq" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/spawner/lootdrop/memeorgans,
@@ -16021,6 +16202,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
 "RB" = (
@@ -16142,6 +16324,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
 "Sd" = (
@@ -16186,6 +16369,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"Sk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "Sl" = (
 /obj/structure/grille,
 /turf/open/transparent/openspace/airless,
@@ -16528,6 +16717,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"TJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/maintenance/aft/upper)
 "TO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -16653,6 +16850,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"Uz" = (
+/obj/effect/turf_decal/trimline/white/end{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "UA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -16906,6 +17109,11 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"Vw" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/landmark/blobstart,
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "VD" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/brown{
@@ -16952,6 +17160,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"VM" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "VS" = (
 /obj/item/reagent_containers/food/drinks/flask{
 	desc = "The Galaxy's favorite gin, bottled fresh since 2497.";
@@ -17112,6 +17324,10 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"WH" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/fore/upper)
 "WJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 1
@@ -17199,12 +17415,6 @@
 	},
 /turf/open/floor/vault,
 /area/ai_monitored/nuke_storage)
-"WY" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/engine/hull,
-/area/space)
 "WZ" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/structure/barricade/wooden/crude{
@@ -17245,6 +17455,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/tcommsat/server/upper)
 "Xk" = (
@@ -17296,12 +17507,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"Xr" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 6
-	},
-/turf/open/floor/engine/hull,
-/area/space)
 "XA" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/neutral,
@@ -17483,6 +17688,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"XZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/medical/abandoned)
 "Yi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17554,6 +17766,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
 "Yx" = (
@@ -17643,6 +17857,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
 "YJ" = (
@@ -17678,6 +17893,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"YN" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "YR" = (
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/engine/gravity_generator)
@@ -35368,25 +35590,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
 ab
 ab
 ab
@@ -35625,25 +35847,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+HK
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+fd
+Jy
 ab
 ab
 ab
@@ -35882,25 +36104,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -36139,25 +36361,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -36396,25 +36618,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -36653,25 +36875,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -36910,25 +37132,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -37167,25 +37389,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -37424,25 +37646,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -37681,25 +37903,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -37938,25 +38160,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -38195,25 +38417,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -38452,25 +38674,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -38709,25 +38931,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -38966,25 +39188,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Om
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+yy
+Jy
 ab
 ab
 ab
@@ -39223,25 +39445,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Jy
+Wl
+XG
+XG
+XG
+XG
+XG
+XG
+Kf
+XG
+XG
+XG
+XG
+XG
+XG
+XG
+XG
+Ir
+Jy
 ab
 ab
 ab
@@ -39480,25 +39702,25 @@ hC
 gS
 hC
 gS
-hC
-gU
-gU
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+YN
+VM
+VM
+Jy
+Jy
+Jy
+Jy
+Jy
+bn
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
 ab
 ab
 ab
@@ -39744,9 +39966,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+Jy
+Uz
+Jy
 ab
 ab
 ab
@@ -42308,7 +42530,7 @@ eY
 HH
 kw
 lC
-ms
+bK
 nk
 Tz
 HH
@@ -43584,7 +43806,7 @@ ab
 ab
 bT
 cY
-ea
+IJ
 eT
 fU
 On
@@ -45420,11 +45642,11 @@ CM
 Bk
 Bk
 Kh
-WY
-WY
-WY
-WY
-Kp
+KU
+KU
+KU
+KU
+fd
 ab
 ab
 ab
@@ -45657,7 +45879,7 @@ pw
 Kz
 bT
 rz
-sh
+JE
 sQ
 tv
 ul
@@ -45677,11 +45899,11 @@ Bk
 Bk
 Bk
 FJ
-GO
-GO
-GO
-GO
-IN
+az
+az
+az
+az
+yy
 ab
 ab
 ab
@@ -45934,11 +46156,11 @@ Bk
 Bk
 Bk
 FJ
-GO
-GO
-GO
-GO
-IN
+az
+az
+az
+az
+yy
 ab
 ab
 ab
@@ -46191,11 +46413,11 @@ Bk
 Ca
 Bk
 FJ
-GO
-GO
-GO
-GO
-IN
+az
+az
+az
+az
+yy
 ab
 ab
 ab
@@ -46424,7 +46646,7 @@ Rh
 ny
 Vi
 mF
-px
+Ew
 qn
 lQ
 rH
@@ -46434,7 +46656,7 @@ lQ
 un
 vm
 vV
-wG
+Sk
 wG
 yb
 yH
@@ -46448,11 +46670,11 @@ Bk
 Bk
 Bk
 FJ
-GO
-GO
-GO
-GO
-IN
+az
+az
+az
+az
+yy
 ab
 ab
 ab
@@ -46705,11 +46927,11 @@ Bm
 EF
 Bm
 FK
-GO
-GO
-GO
-GO
-IN
+az
+az
+az
+az
+yy
 ab
 ab
 ab
@@ -46928,10 +47150,10 @@ LM
 ei
 ff
 WQ
-Zv
+af
 bT
 iX
-jM
+Qp
 kK
 lO
 mI
@@ -46962,11 +47184,11 @@ DZ
 EG
 Fq
 FL
-rp
-NR
-NR
-NR
-Xr
+ag
+XG
+XG
+XG
+Ir
 ab
 ab
 ab
@@ -47724,7 +47946,7 @@ uv
 yg
 yN
 zQ
-zQ
+TJ
 Bp
 zQ
 Bp
@@ -49002,14 +49224,14 @@ sx
 ta
 tA
 ux
-ux
+Lc
 wd
 wO
 xv
 yl
 yR
 yS
-yR
+Ff
 yS
 yo
 yS
@@ -49772,7 +49994,7 @@ rQ
 nI
 Wo
 JX
-tB
+cH
 tC
 wg
 wO
@@ -50010,13 +50232,13 @@ bs
 Vu
 du
 cg
-aY
+XZ
 cf
 hk
 hZ
 cb
 jX
-bd
+WH
 lh
 ii
 nI
@@ -50293,7 +50515,7 @@ wS
 xx
 yp
 xx
-yp
+MA
 Az
 Bt
 Ch
@@ -50536,7 +50758,7 @@ ii
 nI
 ov
 oT
-pJ
+Jf
 qx
 nI
 nQ
@@ -51045,7 +51267,7 @@ ib
 jc
 ci
 WO
-by
+Ls
 ii
 nJ
 nI
@@ -51302,7 +51524,7 @@ ic
 jd
 ci
 kV
-by
+LT
 ii
 nI
 ox
@@ -52338,7 +52560,7 @@ oA
 pN
 qC
 nb
-nQ
+Vw
 oC
 tc
 tF
@@ -52590,7 +52812,7 @@ kZ
 lT
 jb
 jb
-oB
+Nm
 oB
 pO
 oA
@@ -53098,7 +53320,7 @@ Au
 gy
 hp
 dD
-gD
+KD
 kd
 lb
 jU
@@ -54119,7 +54341,7 @@ iQ
 iQ
 bc
 Qq
-cs
+Dn
 dD
 dD
 dD
@@ -54139,7 +54361,7 @@ yF
 nb
 nQ
 oC
-nQ
+Vw
 tG
 uJ
 vB
@@ -54413,7 +54635,7 @@ RN
 LD
 zf
 tB
-wg
+PO
 FW
 DX
 ab
@@ -54899,12 +55121,12 @@ eB
 ih
 ji
 bd
-bx
+KB
 by
 nc
 nQ
 nQ
-nQ
+Vw
 nQ
 nQ
 ri
@@ -56438,7 +56660,7 @@ LP
 Mu
 gI
 bg
-im
+OS
 jl
 kj
 lm
@@ -57743,7 +57965,7 @@ uP
 pW
 oC
 oC
-nQ
+Vw
 yz
 zp
 Al

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -129,6 +129,20 @@
 "az" = (
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"aF" = (
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "aG" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -1910,6 +1924,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
+"fD" = (
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "fE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2379,6 +2410,8 @@
 /turf/open/transparent/openspace,
 /area/security/brig)
 "gH" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gI" = (
@@ -2413,10 +2446,13 @@
 /area/solar/port/fore)
 "gN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/security/prison)
 "gO" = (
@@ -2637,6 +2673,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "hy" = (
@@ -3125,6 +3164,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ix" = (
@@ -3139,6 +3181,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iy" = (
@@ -3148,6 +3193,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3159,11 +3207,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/cryopod,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iB" = (
@@ -3647,6 +3704,9 @@
 "jx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jy" = (
@@ -4033,12 +4093,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/food/plant_smudge,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ks" = (
@@ -4472,7 +4541,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/toilet)
 "ls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
@@ -4481,7 +4550,7 @@
 /obj/item/soap/nanotrasen,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/freezer,
-/area/security/prison)
+/area/security/prison/toilet)
 "lt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/eastleft,
@@ -4490,9 +4559,15 @@
 	name = "old sink";
 	pixel_y = 28
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/toilet)
 "lu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "lv" = (
@@ -4759,22 +4834,24 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/toilet)
 "mj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/freezer,
-/area/security/prison)
+/area/security/prison/toilet)
 "mk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/toilet)
 "ml" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
@@ -7157,6 +7234,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"rp" = (
+/obj/effect/turf_decal/trimline/white/corner,
+/turf/open/floor/engine/hull,
+/area/space)
 "rq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7203,17 +7284,22 @@
 /turf/open/transparent/openspace,
 /area/bridge)
 "rw" = (
-/turf/open/floor/plating/airless,
-/area/space)
-"rx" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating/airless,
 /area/space)
+"rx" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating/airless,
+/area/space)
 "ry" = (
-/obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/upper)
 "rz" = (
@@ -7495,10 +7581,8 @@
 /turf/open/transparent/openspace,
 /area/bridge)
 "sg" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/upper)
 "sh" = (
@@ -7861,11 +7945,8 @@
 /turf/open/transparent/openspace/airless,
 /area/space)
 "sL" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/upper)
 "sM" = (
@@ -8591,10 +8672,6 @@
 	c_tag = "Bridge - Lieutenant's Office";
 	dir = 4;
 	name = "command camera"
-	},
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/solgov)
@@ -9492,7 +9569,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_officer,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -9500,6 +9576,7 @@
 	dir = 1;
 	pixel_y = 30
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wN" = (
@@ -9871,6 +9948,25 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar/atrium)
+"xH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xI" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -13410,6 +13506,9 @@
 	},
 /turf/open/transparent/openspace,
 /area/crew_quarters/bar/atrium)
+"GO" = (
+/turf/open/floor/engine/hull,
+/area/space)
 "GQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -13725,6 +13824,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"If" = (
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "Ij" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13742,11 +13858,15 @@
 	},
 /area/crew_quarters/abandoned_gambling_den)
 "In" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/structure/barricade/wooden/crude{
 	layer = 3.3;
 	opacity = 1
 	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/window,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "Ir" = (
@@ -13822,6 +13942,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
+"IN" = (
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/engine/hull,
+/area/space)
 "IO" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14157,6 +14281,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"Kh" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/turf_decal/trimline/white/corner{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoorExt";
+	name = "cargo docking door"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/quartermaster/storage)
 "Kl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/airalarm/directional/west,
@@ -14169,6 +14305,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore/upper)
+"Kp" = (
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 10
+	},
+/turf/open/floor/engine/hull,
+/area/space)
 "Ks" = (
 /obj/structure/curtain/cloth,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -14218,6 +14360,9 @@
 /obj/item/caution,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/fore/upper)
+"KF" = (
+/turf/closed/wall,
+/area/security/prison/toilet)
 "KH" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -14730,6 +14875,9 @@
 	},
 /turf/open/transparent/openspace,
 /area/engine/engineering)
+"MD" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/toilet)
 "MF" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp,
@@ -14807,6 +14955,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"MY" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/transparent/openspace/airless,
+/area/space)
 "Nc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -14989,7 +15141,6 @@
 	name = "Prison Wing";
 	req_access_txt = "1"
 	},
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Security Blast Door"
@@ -15018,6 +15169,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"NR" = (
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/space)
 "NT" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -16886,10 +17043,11 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "Ww" = (
@@ -17005,6 +17163,12 @@
 	},
 /turf/open/floor/vault,
 /area/ai_monitored/nuke_storage)
+"WY" = (
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/space)
 "WZ" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/structure/barricade/wooden/crude{
@@ -17096,6 +17260,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"Xr" = (
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 6
+	},
+/turf/open/floor/engine/hull,
+/area/space)
 "XA" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/neutral,
@@ -17226,7 +17396,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "XR" = (
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "Security Blast Door"
@@ -17271,6 +17440,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/crew_quarters/bar/atrium)
+"XY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "Yi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31044,6 +31220,7 @@ ab
 ab
 ab
 ab
+MY
 ab
 ab
 ab
@@ -31075,8 +31252,7 @@ ab
 ab
 ab
 ab
-ab
-ab
+MY
 ab
 ab
 ab
@@ -32278,7 +32454,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -40048,7 +40224,7 @@ gU
 gU
 ab
 ab
-ab
+sK
 ab
 ab
 ab
@@ -40305,7 +40481,7 @@ pY
 gU
 ab
 ab
-sK
+ab
 ab
 ab
 ab
@@ -41513,7 +41689,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -45206,12 +45382,12 @@ Bk
 CM
 Bk
 Bk
-FJ
-ab
-ab
-ab
-ab
-ab
+Kh
+WY
+WY
+WY
+WY
+Kp
 ab
 ab
 ab
@@ -45464,11 +45640,11 @@ Bk
 Bk
 Bk
 FJ
-ab
-ab
-ab
-ab
-ab
+GO
+GO
+GO
+GO
+IN
 ab
 ab
 ab
@@ -45721,11 +45897,11 @@ Bk
 Bk
 Bk
 FJ
-ab
-ab
-ab
-ab
-ab
+GO
+GO
+GO
+GO
+IN
 ab
 ab
 ab
@@ -45978,11 +46154,11 @@ Bk
 Ca
 Bk
 FJ
-ab
-ab
-ab
-ab
-ab
+GO
+GO
+GO
+GO
+IN
 ab
 ab
 ab
@@ -46235,11 +46411,11 @@ Bk
 Bk
 Bk
 FJ
-ab
-ab
-ab
-ab
-ab
+GO
+GO
+GO
+GO
+IN
 ab
 ab
 ab
@@ -46492,6 +46668,11 @@ Bm
 EF
 Bm
 FK
+GO
+GO
+GO
+GO
+IN
 ab
 ab
 ab
@@ -46509,12 +46690,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
+MY
 ab
 ab
 ab
@@ -46749,11 +46925,11 @@ DZ
 EG
 Fq
 FL
-ab
-ab
-ab
-ab
-ab
+rp
+NR
+NR
+NR
+Xr
 ab
 ab
 ab
@@ -52701,7 +52877,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -53092,7 +53268,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -56736,7 +56912,7 @@ bJ
 cF
 dI
 eD
-fE
+xH
 QP
 bg
 io
@@ -59054,10 +59230,10 @@ oE
 cO
 iv
 ju
-cO
+KF
 lr
 mi
-bh
+MD
 nR
 oC
 pf
@@ -59311,7 +59487,7 @@ gN
 hx
 iw
 UJ
-cO
+KF
 ls
 mj
 ne
@@ -59568,7 +59744,7 @@ gO
 gO
 ix
 cO
-cO
+KF
 lt
 mk
 nf
@@ -60083,7 +60259,7 @@ hz
 iz
 jx
 kq
-dR
+XY
 mm
 nf
 nU
@@ -60593,10 +60769,10 @@ ab
 ab
 bh
 bR
-In
-In
+aF
+If
 bh
-In
+fD
 In
 bR
 bh
@@ -62112,7 +62288,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -64774,7 +64950,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -68557,7 +68733,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab
@@ -71409,7 +71585,7 @@ ab
 ab
 ab
 ab
-ab
+MY
 ab
 ab
 ab

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -1628,6 +1628,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
 "eZ" = (
@@ -3346,6 +3347,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
 "iN" = (
@@ -3806,6 +3808,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jK" = (
@@ -4983,6 +4986,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad/emergency/engineering,
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
 "mD" = (
@@ -4996,7 +5000,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mE" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
@@ -6320,6 +6323,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
 "pr" = (
@@ -17554,6 +17558,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
 "YA" = (

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -15227,6 +15227,7 @@
 /area/maintenance/central)
 "Nu" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "NB" = (

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -137,6 +137,16 @@
 "az" = (
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"aC" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "aF" = (
 /obj/structure/barricade/wooden/crude{
 	layer = 3.3;
@@ -6257,6 +6267,12 @@
 /obj/item/radio/intercom{
 	pixel_y = -32
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/transparent/openspace,
 /area/maintenance/central)
 "pf" = (
@@ -6286,6 +6302,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -8271,6 +8290,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/solgov)
+"tJ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "tK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9150,6 +9179,16 @@
 "vF" = (
 /turf/closed/wall/r_wall,
 /area/bridge)
+"vG" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "vH" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
@@ -9496,6 +9535,12 @@
 /obj/structure/lattice,
 /obj/item/radio/intercom{
 	pixel_y = 32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/maintenance/central)
@@ -11499,6 +11544,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "Bc" = (
@@ -11531,6 +11579,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -13739,6 +13790,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "HB" = (
@@ -14484,6 +14538,16 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
+"KC" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "KD" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/landmark/blobstart,
@@ -15003,6 +15067,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -16631,6 +16698,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "Tr" = (
@@ -17900,6 +17970,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "YN" = (
@@ -18260,6 +18333,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft/upper)
+"ZZ" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 
 (1,1,1) = {"
 ab
@@ -54882,9 +54965,9 @@ nb
 pR
 nb
 nb
-nQ
-oC
-nQ
+KC
+tJ
+KC
 tF
 tF
 tG
@@ -55904,8 +55987,8 @@ Ij
 lj
 lX
 Vt
-nQ
-oD
+KC
+vG
 pe
 pS
 pS
@@ -55917,8 +56000,8 @@ tg
 tg
 tg
 wt
-oD
-nQ
+ZZ
+aC
 yz
 zj
 Aj

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -11102,7 +11102,7 @@
 "Am" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
-	name = "Cabin 4"
+	name = "Cabin 1"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11112,7 +11112,7 @@
 "An" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm5";
-	name = "Cabin 5"
+	name = "Cabin 2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14730,6 +14730,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/lawoffice)
+"LQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/departments/mait/alt{
+	pixel_x = -32
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "LU" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -50508,7 +50515,7 @@ pJ
 qx
 nI
 nQ
-nQ
+LQ
 tc
 tD
 tD

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -3,6 +3,9 @@
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "m" = (
@@ -43,7 +46,10 @@
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating,
 /area/shuttle/pod_1)
 "H" = (
 /obj/structure/chair/comfy/shuttle{
@@ -116,15 +122,21 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
-"W" = (
-/turf/closed/wall/mineral/titanium,
-/area/template_noop)
+"Y" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating,
+/area/shuttle/pod_1)
 "Z" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/pod_1)
 
 (1,1,1) = {"
-W
+B
 B
 B
 u
@@ -153,10 +165,10 @@ E
 M
 H
 h
-F
+Y
 "}
 (5,1,1) = {"
-W
+B
 B
 B
 u

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -1,11 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "h" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
 	},
-/obj/item/storage/pod{
-	pixel_x = -24
-	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"m" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/nav,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "r" = (
@@ -16,12 +17,9 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/pod_1)
-"A" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = 30
+"v" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -29,15 +27,31 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_1)
 "C" = (
-/obj/machinery/computer/shuttle/monastery_shuttle,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/helm,
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"E" = (
+/obj/machinery/computer/shuttle/monastery_shuttle{
+	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station;mining_public"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"F" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/pod_1)
 "H" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -46,13 +60,21 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/item/storage/pod{
+	pixel_x = -24
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "L" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -61,7 +83,11 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/item/radio/intercom/wideband{
+	pixel_x = 28
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -76,14 +102,25 @@
 	port_direction = 2;
 	width = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
+"U" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "W" = (
-/turf/template_noop,
+/turf/closed/wall/mineral/titanium,
 /area/template_noop)
 "Z" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/pod_1)
 
 (1,1,1) = {"
@@ -96,27 +133,27 @@ Z
 "}
 (2,1,1) = {"
 B
-B
+m
 J
 L
 h
-Z
+F
 "}
 (3,1,1) = {"
 u
 C
 r
-r
-r
+U
+v
 O
 "}
 (4,1,1) = {"
 B
-B
+E
 M
 H
-A
-Z
+h
+F
 "}
 (5,1,1) = {"
 W


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a bunch of requested changes to Galaxy.
<details>
  <summary><b>Screenshots</b></summary>

  ![image](https://user-images.githubusercontent.com/29362068/106346373-42232b80-627c-11eb-9759-b0525dea0f98.png)
  ![image](https://user-images.githubusercontent.com/29362068/106346396-7565ba80-627c-11eb-80de-8c6d608dde8e.png)
  ![image](https://user-images.githubusercontent.com/29362068/106346391-6a128f00-627c-11eb-83aa-d99f437ed4e0.png)

</details>

## Why It's Good For The Game
Hopefully enough to get it back into rotation,

## Changelog
:cl:
add: New toxins lab on Galaxy
add: New tech storage on Galaxy
add: New shared toxins/atmos storage room
add: Emergency holopads on Galaxy
tweak: Made Galaxy's tool storage, atmospherics, and engineering foyer bigger
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
