### PR TITLE
Change operators in emergency.dm to prevent errors in LOWMEMORYMODE

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -503,8 +503,8 @@
 				target_area = /area/whitesands/surface/outdoors
 
 	var/list/turfs = get_area_turfs(target_area)
-	var/original_len = turfs.len
-	while(turfs.len)
+	var/original_len = turfs?.len
+	while(turfs?.len)
 		var/turf/T = pick(turfs)
 		if(T.x<edge_distance || T.y<edge_distance || (world.maxx+1-T.x)<edge_distance || (world.maxy+1-T.y)<edge_distance)
 			turfs -= T


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes two operators to avoid null reference errors when LOWMEMORYMODE is defined.
This is absolutely inconsequential to live servers and only acts to prevent unrelated runtime errors from appearing when debugging
