### PR TITLE
This kills the 3x3 Freezer / Heater TEG

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -206,3 +206,5 @@
 
 #define RULE_OF_THREE(a, b, x) ((a*x)/b)
 // )
+
+#define LOGISTIC_FUNCTION(L,k,x,x_0) (L/(1+(NUM_E**(-k*(x-x_0))))) //WS Edit - Function ported from Cit

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -66,7 +66,7 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += energy_transfer*efficiency
+				lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000) //WS Edit - Buries the 3x3 freezer heater TEG into the ground
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the end result of the following Citadel PRs
[#13225](https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13225)
[#13280](https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13280)
[#13421](https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13421)

## Why It's Good For The Game

You can't make stupid amounts of power with just a freezer and heater, you need an actual burn chamber now like intended.

"This changes the way that the TEG's power generation is calculated to be LOGISTICAL rather than LINEAR. You can expect to create about 36kW with a 3x3 build now, but that power generation increases rapidly as you increase the heat past the heat difference that a heater/freezer setup can create."

## Changelog
:cl:
tweak: Thermoelectric Generator power output
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
