### PR TITLE
Lawnmower mows lawns (er... vines)

### DIFF
--- a/whitesands/code/modules/cargo/packs.dm
+++ b/whitesands/code/modules/cargo/packs.dm
@@ -441,3 +441,14 @@
 	cost = 35000
 	contains = list(/obj/machinery/jukebox)
 	crate_name = "Jukebox"
+
+/datum/supply_pack/service/lawnmower
+	name = "Boomer John's Riding Mower"
+	desc = "Can be used to cultivate gardens and shred weeds at record pace. Comes with a complementary can of Monkey Energy."
+	cost = 10000
+	access = ACCESS_HYDROPONICS
+	contains = list(
+		/obj/vehicle/ridden/lawnmower,
+		/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy
+	)
+	crate_name = "mower crate"

--- a/whitesands/code/modules/vehicles/pimpin_ride.dm
+++ b/whitesands/code/modules/vehicles/pimpin_ride.dm
@@ -27,6 +27,7 @@
 	emagged = TRUE
 
 /obj/vehicle/ridden/lawnmower/Bump(atom/A)
+	. = ..()
 	if(emagged)
 		if(isliving(A))
 			var/mob/living/M = A
@@ -35,13 +36,15 @@
 			M.throw_at(newLoc, 4, 1)
 
 /obj/vehicle/ridden/lawnmower/Move()
-	..()
+	. = ..()
 	var/gibbed = FALSE
 	var/gib_scream = FALSE
 	var/mob/living/carbon/H
 
 	if(has_buckled_mobs())
 		H = buckled_mobs[1]
+	else
+		return .
 
 	if(emagged)
 		for(var/mob/living/carbon/human/M in loc)
@@ -61,6 +64,26 @@
 			playsound(loc, 'sound/voice/gib_scream.ogg', 100, 1, frequency = rand(11025*0.75, 11025*1.25))
 		else
 			playsound(loc, pick(gib_sounds), 75, 1)
-	else
-		playsound(loc, pick(drive_sounds), 75, 1)
 
+	mow_lawn()
+
+/obj/vehicle/ridden/lawnmower/proc/mow_lawn()
+	//Nearly copypasted from goats
+	var/mowed = FALSE
+	var/obj/structure/spacevine/SV = locate(/obj/structure/spacevine) in loc
+	if(SV)
+		SV.eat(src)
+		mowed = TRUE
+
+	var/obj/structure/glowshroom/GS = locate(/obj/structure/glowshroom) in loc
+	if(GS)
+		qdel(GS)
+		mowed = TRUE
+
+	var/obj/structure/alien/weeds/AW = locate(/obj/structure/alien/weeds) in loc
+	if(AW)
+		qdel(AW)
+		mowed = TRUE
+
+	if(mowed)
+		playsound(loc, pick(drive_sounds), 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![mower](https://user-images.githubusercontent.com/39249137/107090193-73907f80-67c5-11eb-9874-25ee90fa90ea.gif)
The lawnmower now deletes any spacevine, glowshrooms, and alien weeds it comes across.
Additionally, the lawnmower actually needs to be driven to mow, opposed to before where you could just push it into things.

Now includes a non-emagged mower in the service tab of cargo for 10,000 credits and restricted to botany.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things should be able to do the thing they are named after for doing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Lawnmowers now mow lawns
tweak: Lawnmowers mow lawns when lawnmower loans a lawn owner for operation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
