### PR TITLE
Autolathe item fixes

### DIFF
--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -12,6 +12,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("swept", "brushed off", "bludgeoned", "whacked")
 	resistance_flags = FLAMMABLE
+	custom_materials = list(/datum/material/iron = 2000) // WS Edit - Item Materials
 
 /obj/item/pushbroom/Initialize()
 	. = ..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -634,6 +634,8 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	desc = "A metallic container containing tasty paint."
 
+	custom_materials = list(/datum/material/iron = 100, /datum/material/glass = 100) // WS Edit - Item Materials
+
 	instant = TRUE
 	edible = FALSE
 	has_cap = TRUE

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -278,6 +278,7 @@
 	icon_state = "tile_bcircuit"
 	item_state = "tile-bcircuit"
 	turf_type = /turf/open/floor/circuit
+	custom_materials = list(/datum/material/iron = 500, /datum/material/glass = 500) // WS Edit - Item Materials
 
 /obj/item/stack/tile/circuit/green
 	name = "green circuit tile"

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -58,6 +58,8 @@
 
 	slot_flags = ITEM_SLOT_MASK
 
+	custom_materials = list(/datum/material/iron = 150) // WS Edit - Item Materials
+
 	var/plunge_mod = 1 //time*plunge_mod = total time we take to plunge an object
 	var/reinforced = FALSE //whether we do heavy duty stuff like geysers
 

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -8,6 +8,7 @@
 	icon_state_unpowered = "laptop-off"
 	icon_state_menu = "menu"
 	display_overlays = FALSE
+	custom_materials = list(/datum/material/iron = 10000, /datum/material/glass = 1000) // WS Edit - Item Materials
 
 	hardware_flag = PROGRAM_LAPTOP
 	max_hardware_size = 2

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -12,6 +12,7 @@
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT
 	has_light = TRUE //LED flashlight!
 	comp_light_luminosity = 2.3 //Same as the PDA
+	custom_materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000) // WS Edit - Item Materials
 	var/has_variants = TRUE
 	var/finish_color = null
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -354,6 +354,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	w_class = WEIGHT_CLASS_BULKY
+	custom_materials = list(/datum/material/iron = 450, /datum/material/glass = 190) // WS Edit - Item Materials
 	var/id = "" //inherited by the switch
 
 /obj/item/conveyor_switch_construct/Initialize()
@@ -389,6 +390,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	max_amount = 30
 	singular_name = "conveyor belt"
 	w_class = WEIGHT_CLASS_BULKY
+	custom_materials = list(/datum/material/iron = 3000) // WS Edit - Item Materials
 	///id for linking
 	var/id = ""
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1118,6 +1118,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	machine_name = "Custom Vendor"
 	icon_state = "refill_custom"
 	custom_premium_price = 100
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/glass = 2000) // WS Edit - Item Materials
 
 /obj/item/price_tagger
 	name = "price tagger"
@@ -1127,6 +1128,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	custom_premium_price = 25
 	///the price of the item
 	var/price = 1
+	custom_materials = list(/datum/material/iron = 1500, /datum/material/glass = 500) // WS Edit - Item Materials
 
 /obj/item/price_tagger/attack_self(mob/user)
 	price = max(1, round(input(user,"set price","price") as num|null, 1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's a bunch of items that currently don't have `custom_material` defines so they can't be reinserted into the autolathe after being made.

## Why It's Good For The Game

Recycling will be necessary when we Make SS13 Poor Again.

## Changelog
:cl:
tweak: several items from the autolathe now have `custom_materials` defines so they can be reinserted to lathes.
/:cl:

