### PR TITLE
Adds solar assemblies to construct-able things in engineering lathes

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -141,10 +141,10 @@
 	display_name = "Industrial Engineering"
 	description = "A refresher course on modern engineering technology."
 	prereq_ids = list("base")
-	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
+	design_ids = list("solarcontrol", "solarassembly", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "welding_goggles", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "aac_electronics", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine",
-	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt")
+	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt")	//WS edit, solar assemblies from lathe
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3471,6 +3471,7 @@
 #include "whitesands\code\modules\research\designs\comp_board_designs.dm"
 #include "whitesands\code\modules\research\designs\machine_designs.dm"
 #include "whitesands\code\modules\research\designs\mechfabricator_designs.dm"
+#include "whitesands\code\modules\research\designs\power_designs.dm"
 #include "whitesands\code\modules\research\designs\spacepod_designs.dm"
 #include "whitesands\code\modules\research\designs\tool_designs.dm"
 #include "whitesands\code\modules\research\techweb\all_nodes.dm"

--- a/whitesands/code/modules/research/designs/power_designs.dm
+++ b/whitesands/code/modules/research/designs/power_designs.dm
@@ -1,0 +1,9 @@
+/datum/design/board/solar
+	name = "Solar Assembly"
+	desc = "The basis of all solar power"
+	id = "solarassembly"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/silver = 500, /datum/material/iron = 2500, /datum/material/glass = 1000)
+	build_path = /obj/item/solar_assembly
+	category = list("Power Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds solar assemblies to the Industrial Engineering research node, which can then be produced for 500 silver, 2500 iron and 1000 glass (tier 1) at any lathe with the engineering bit set.
![image](https://user-images.githubusercontent.com/59462654/107854383-7143ac00-6de9-11eb-932f-b0e8dadc61c3.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
PR is primarily targeted for derelict drone players, however it just seems fair that we shouldn't be dependent on centcom for freakin solar panels.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Solar assemblies can be made in engineering lathes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
