### PR TITLE
manly dorf and dorf drinking fix

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -56,6 +56,10 @@
 #define MARTYRDOM	/datum/mutation/human/martyrdom
 #define HARS		/datum/mutation/human/headless
 
+// WS Edit Start - Dwarves
+#define DORFISM		/datum/mutation/human/dorfism
+// WS Edit End - Dwarves
+
 #define UI_CHANGED "ui changed"
 #define UE_CHANGED "ue changed"
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -545,7 +545,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			Dizzy(10)
 
 		if(drunkenness >= 51)
-			if(prob(3))
+			if(prob(3) && !dna.check_mutation(DORFISM)) //WS Edit - they can handle their drink to keep it down
 				confused += 15
 				vomit() // vomiting clears toxloss, consider this a blessing
 			Dizzy(25)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -718,9 +718,15 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(HAS_TRAIT(H, TRAIT_DWARF) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE))
+			// WS Edit Start - Dorfisms
 			to_chat(H, "<span class='notice'>Now THAT is MANLY!</span>")
-			boozepwr = 5 //We've had worse in the mines
 			dorf_mode = TRUE
+			if(H.dna && H.dna.check_mutation(DORFISM))
+				boozepwr = 120 //lifeblood of dwarves (boozepower = nutrition)
+				quality = DRINK_FANTASTIC //dorf drink for dorfs to drink
+			else
+				boozepwr = 5 //We've had worse in the mines
+			// WS Edit End - Dorfisms
 
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/M)
 	if(dorf_mode)

--- a/whitesands/code/__DEFINES/DNA.dm
+++ b/whitesands/code/__DEFINES/DNA.dm
@@ -1,2 +1,1 @@
 //Defines copying names of mutations in all cases, make sure to change this if you change mutation's type
-#define DORFISM	/datum/mutation/human/dorfism


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so manly dorf has a higher boozepower for true dwarves now as boozepower = nutrition and this led to starving every round (changed from 5 to 120), fake dwarves are not affected by this. Also stops true dwarves throwing up because this also led to starving everyround too as you are guaranteed to lose nutrition from the thing you need to drink. Puts the DORFISM mutation in the right folder too because it wasnt working in the whitesands path.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more starving dorfs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Makes manly dorf give true dwarves high boozepower
add: Stops dorves being sick from drinking
fix: moves DORFISM mutation in main file to make it work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
