### PR TITLE
Fix Buttons Disabled while Buckled

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -626,7 +626,7 @@ so as to remain in compliance with the most up-to-date laws."
 	if(!istype(L) || !L.can_resist() || L != owner)
 		return
 	L.changeNext_move(CLICK_CD_RESIST)
-	if((L.mobility_flags & MOBILITY_MOVE) && (L.last_special <= world.time))
+	if((L.mobility_flags & MOBILITY_MOVE) && (L.last_special <= world.time) && !L.buckled)           // WS Edit - cuff resist while buckled fail fast
 		return L.resist_restraints()
 
 /obj/screen/alert/restrained/buckled/Click()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1657,7 +1657,7 @@
 	. = buckled
 	buckled = new_buckled
 	if(buckled)
-		ADD_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)
+		//ADD_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)         // WS Edit - Can use buttons in chairs again
 		switch(buckled.buckle_lying)
 			if(NO_BUCKLE_LYING) // The buckle doesn't force a lying angle.
 				REMOVE_TRAIT(src, TRAIT_FLOORED, BUCKLED_TRAIT)
@@ -1670,7 +1670,7 @@
 				set_body_position(LYING_DOWN)
 				set_lying_angle(buckled.buckle_lying)
 	else
-		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)
+		//REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)      // WS Edit - Can use buttons in chairs again
 		REMOVE_TRAIT(src, TRAIT_FLOORED, BUCKLED_TRAIT)
 		if(.) // We unbuckled from something.
 			var/atom/movable/old_buckled = .


### PR DESCRIPTION
## About The Pull Request

I did some tracing, and this is what appears to be happening with #740:

buckle_mob() calls set_buckled(), on line 81 of buckling.dm
set_buckled() adds the trait TRAIT_IMMOBILIZED, on line 1660 of living.dm
Trigger() calls IsAvailable() to see if an action (button) can run, on line 88 of action.dm
IsAvailable() returns FALSE if the action has AB_CHECK_IMMOBILE and the user has TRAIT_IMMOBILIZED, on line 100 of action.dm
The parent of the majority of actions, /datum/action/item_action, has the following check_flags set:
AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_LYING|AB_CHECK_CONSCIOUS, on line 149 of action.dm
Thus the vast majority of actions will fail when buckled.

Since this is only an issue when buckled to a chair, I just removed the line that sets TRAIT_IMMOBILIZED in set_buckled().

I have confirmed that buttons work multiple types of chairs, including wheelchairs.
I have also confirmed that buttons continue to not work while cuffed.

Known issue: 
If cuffed and buckled, trying to remove the cuffs first will show a timer, but fail to remove the cuffs.  
Clicking resist will always do them in the correct order

Cause:
on_immobilized_trait_gain() removes the flag MOBILITY_MOVE, on line 66 of init_signals.dm
/obj/screen/alert/restrained/Click() is called when resisting out of cuff via the alerts
Previously it would use MOBILITY_MOVE to determine if the user was buckled, on line 629 of alert.dm
Because TRAIT_IMMOBILIZED is no longer applied when buckled, this no longer works to check if the player is buckled
This allows calls to resist_restraints(), cuff_resist(), and clear_cuffs().
cuff_resist() applies the timer, and clear_cuffs returns (failure to uncuff) after a check to see if the player is buckled

Solution:
I added a check to see if the player is buckled in /obj/screen/alert/restrained/Click().
This stops the pointless timer.

## Why It's Good For The Game

BugFix #740 

## Changelog
:cl:
fix: Buttons work while buckled again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
