### PR TITLE
Numbers in IPC Name Fix

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -437,7 +437,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
 
 	//Sanitize
-	real_name = reject_bad_name(real_name)
+	real_name = reject_bad_name(real_name, pref_species.allow_numbers_in_name)      // WS Edit - numbers in IPC names load from save
 	gender = sanitize_gender(gender)
 	if(!real_name)
 		real_name = random_unique_name(gender)


### PR DESCRIPTION
## About The Pull Request

When the savefile loads, the name sanitizer runs again.  It wasn't being passed the bool that tells it if numbers are allowed in the character name for a given species.

## Why It's Good For The Game

BugFix #714 

## Changelog
:cl:
fix: Numbers in IPC names persist
/:cl: