### PR TITLE
Fixed Missing Metacoin Items

### DIFF
--- a/whitesands/code/modules/client/loadout/loadout_hat.dm
+++ b/whitesands/code/modules/client/loadout/loadout_hat.dm
@@ -108,7 +108,7 @@
 	path = /obj/item/clothing/head/cowboy
 	cost = 1500
 
-/datum/gear/hat/tinfoil
+/datum/gear/hat/catears
 	display_name = "cat ears"
 	path = /obj/item/clothing/head/kitty
 	cost = 5000

--- a/whitesands/code/modules/client/loadout/loadout_suit.dm
+++ b/whitesands/code/modules/client/loadout/loadout_suit.dm
@@ -25,7 +25,7 @@
 	display_name = "leather jacket"
 	path = /obj/item/clothing/suit/jacket/leather
 
-/datum/gear/suit/jacket/leather
+/datum/gear/suit/jacket/military
 	display_name = "military jacket"
 	path = /obj/item/clothing/suit/jacket/miljacket
 
@@ -37,11 +37,11 @@
 	display_name = "goth jacket"
 	path = /obj/item/clothing/suit/gothcoat
 
-/datum/gear/suit/bronze
+/datum/gear/suit/jacket/bronze
 	display_name = "bronze suit"
 	path = /obj/item/clothing/suit/bronze
 
-/datum/gear/suit/yakuza
+/datum/gear/suit/jacket/yakuza
 	display_name = "yakuza suit"
 	path = /obj/item/clothing/suit/yakuza
 

--- a/whitesands/code/modules/client/loadout/loadout_uniform.dm
+++ b/whitesands/code/modules/client/loadout/loadout_uniform.dm
@@ -103,7 +103,7 @@
 	display_name = "suitskirt, white shirt"
 	path = /obj/item/clothing/under/suit/black/skirt
 
-/datum/gear/uniform/suit/white
+/datum/gear/uniform/suit/white_shirt
 	display_name = "suit, white shirt"
 	path = /obj/item/clothing/under/suit/black
 //Premium


### PR DESCRIPTION
## About The Pull Request

The following metacoin items were missing from the actual gear tab: leather jacket, tinfoil hat, white suit, bronze suit, and yakuza suit

The first three were copy/paste errors where a later item used the same path and overwrote the item.
The last two were missing the cost var.  I fixed this by subtyping them from /datum/gear/suit/jacket, which has a  default cost of 1000.

Example of items loading in the character setup window:
![image](https://user-images.githubusercontent.com/7697956/109370564-7af7f580-7866-11eb-9ae2-32e23273ad4f.png)
![image](https://user-images.githubusercontent.com/7697956/109370589-8ea35c00-7866-11eb-8909-2182b6440135.png)
![image](https://user-images.githubusercontent.com/7697956/109370599-9bc04b00-7866-11eb-9da3-ae2597eee28a.png)
![image](https://user-images.githubusercontent.com/7697956/109370618-abd82a80-7866-11eb-8f6d-2fd6a841cdc8.png)
![image](https://user-images.githubusercontent.com/7697956/109370628-b5fa2900-7866-11eb-866a-0bae0f8ff8b4.png)

I've also confirmed that the military jacket, cat ears, and white-shirt suit still work.

## Why It's Good For The Game

BugFix: Missing metacoin items

## Changelog
:cl:
fix: Fixed some missing metacoin items
/:cl:
