### PR TITLE
Add flavor text verb when in-game

### DIFF
--- a/whitesands/code/modules/mob/say_vr.dm
+++ b/whitesands/code/modules/mob/say_vr.dm
@@ -5,7 +5,10 @@
 	var/flavor_text = "" //tired of fucking double checking this
 
 /mob/proc/update_flavor_text()
+	set name = "Update Flavor Text"
+	set category = "IC"
 	set src in usr
+
 	if(usr != src)
 		usr << "No."
 	var/msg = input(usr,"Set the flavor text in your 'examine' verb. Can also be used for OOC notes about your character.","Flavor Text",html_decode(flavor_text)) as message|null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a verb for changing your flavor text while in-game, instead of only being available in preferences.

Sidenote, I haven't been able to test this because I'm running the latest version of DM which is horrifically broken. Yay me. But I think it should still work.

## Why It's Good For The Game

People might want to change their flavor text mid-round or realize they made a typo/mistake/etc.

## Changelog
:cl:
add: You can now change your flavor text mid-round via a new verb in the IC tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
