### PR TITLE
Update text obfs subsystem strings to properly decode with the new world.url

### DIFF
--- a/whitesands/code/controllers/subsystem/textobfs.dm
+++ b/whitesands/code/controllers/subsystem/textobfs.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(textobfs)
 	var/worldURL
 	var/list/obf_string_list = new/list(OBF_STRING_COUNT, 4)
 	obf_string_list = list(
-		list("", "=6lmEE", "86b2e660bccec5a7c753808babafb2fa", "meatball")
+		list("", "9b?7Bu", "8953cce23a01b268a7cc2e4bee164da5", "meatball")
 	)
 
 /datum/controller/subsystem/textobfs/Initialize()

--- a/whitesands/code/controllers/subsystem/textobfs.dm
+++ b/whitesands/code/controllers/subsystem/textobfs.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(textobfs)
 	var/worldURL
 	var/list/obf_string_list = new/list(OBF_STRING_COUNT, 4)
 	obf_string_list = list(
-		list("", "9b?7Bu", "8953cce23a01b268a7cc2e4bee164da5", "meatball")
+		list("", ":d><Fy", "d907935191deb1b56b4f006be17013b4", "meatball")
 	)
 
 /datum/controller/subsystem/textobfs/Initialize()


### PR DESCRIPTION
New world.url is byond://ss13.white-sands.space:5513, as this has changed the textObfs subsystem had been resorting to fallbacks.
Keys can be deobfusticated at "\tools\obfStringgenerator"