### PR TITLE
Add turtleneck as alternate HoS uniform

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -40,6 +40,7 @@
 	belt = /obj/item/pda/heads/hos
 	ears = /obj/item/radio/headset/heads/hos/alt
 	uniform = /obj/item/clothing/under/rank/security/head_of_security
+	alt_uniform = /obj/item/clothing/under/rank/security/head_of_security/alt
 	shoes = /obj/item/clothing/shoes/jackboots
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
 	alt_suit = /obj/item/clothing/suit/armor/vest/security/hos


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the HoS' turtleneck (already available in their locker) as the alternate jumpsuit for the character preferences.

## Why It's Good For The Game

The HoS turtleneck is really cool looking and it's nice to have options in preferences rather than having to play dressup in your locker.

## Changelog
:cl:
tweak: You can now select the Head of Security's turtleneck as an alternate jumpsuit in your character preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
