### PR TITLE
Causes certain sounds to play in mono if you are right next to the source

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
- #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+// #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-// #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+ #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -185,7 +185,7 @@
 	if(density && has_hatch && (mover.pass_flags & PASSDOORHATCH) && !hatchstate)
 		hatchstate = 1
 		update_icon()
-		playsound(loc, hatch_open_sound, 40, 1, -1)
+		playsound(loc, hatch_open_sound, 40, 1, -1, mono_adj = TRUE)
 		if(mover.layer != initial(mover.layer))
 			return
 		mover.layer = UNDERDOOR
@@ -199,7 +199,7 @@
 /obj/machinery/door/airlock/proc/close_hatch()
 	hatchstate = 0
 	update_icon()
-	playsound(loc, hatch_close_sound, 30, 1, -1)
+	playsound(loc, hatch_close_sound, 30, 1, -1, mono_adj = TRUE)
 
 /obj/machinery/door/airlock/proc/update_other_id()
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)
@@ -335,7 +335,7 @@
 	if(locked)
 		return
 	locked = TRUE
-	playsound(src,boltDown,30,FALSE,3)
+	playsound(src, boltDown, 30, FALSE, 3, mono_adj = TRUE)
 	audible_message("<span class='hear'>You hear a click from the bottom of the door.</span>", null,  1)
 	update_icon()
 
@@ -346,7 +346,7 @@
 	if(!locked)
 		return
 	locked = FALSE
-	playsound(src,boltUp,30,FALSE,3)
+	playsound(src, boltUp, 30, FALSE, 3, mono_adj = TRUE)
 	audible_message("<span class='hear'>You hear a click from the bottom of the door.</span>", null,  1)
 	update_icon()
 
@@ -724,7 +724,7 @@
 		if("deny")
 			if(!machine_stat)
 				update_icon(AIRLOCK_DENY)
-				playsound(src,doorDeni,50,FALSE,3)
+				playsound(src, doorDeni, 50, FALSE, 3, mono_adj = TRUE)
 				sleep(6)
 				update_icon(AIRLOCK_CLOSED)
 
@@ -1126,7 +1126,7 @@
 
 			if(!prying_so_hard)
 				var/time_to_open = 50
-				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
+				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE, mono_adj = TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
 				if(do_after(user, time_to_open, TRUE, src))
 					open(2)
@@ -1156,11 +1156,11 @@
 		if(obj_flags & EMAGGED)
 			return FALSE
 		use_power(50)
-		playsound(src, doorOpen, 30, TRUE)
+		playsound(src, doorOpen, 30, TRUE, mono_adj = TRUE)
 		if(closeOther != null && istype(closeOther, /obj/machinery/door/airlock/) && !closeOther.density)
 			closeOther.close()
 	else
-		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE)
+		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE, mono_adj = TRUE)
 
 	if(autoclose)
 		autoclose_in(normalspeed ? 150 : 15)
@@ -1204,9 +1204,9 @@
 		if(obj_flags & EMAGGED)
 			return
 		use_power(50)
-		playsound(src, doorClose, 30, TRUE)
+		playsound(src, doorClose, 30, TRUE, mono_adj = TRUE)
 	else
-		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE)
+		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE, mono_adj = TRUE)
 
 	var/obj/structure/window/killthis = (locate(/obj/structure/window) in get_turf(src))
 	if(killthis)
@@ -1313,7 +1313,7 @@
 	var/time_to_open = 5 //half a second
 	if(hasPower())
 		time_to_open = 5 SECONDS //Powered airlocks take longer to open, and are loud.
-		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
+		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE, mono_adj = TRUE)
 
 
 	if(do_after(user, time_to_open, TRUE, src))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -884,7 +884,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		if(islist(usesound))
 			played_sound = pick(usesound)
 
-		playsound(target, played_sound, volume, TRUE)
+		playsound(target, played_sound, volume, TRUE, mono_adj = TRUE)
 
 /// Used in a callback that is passed by use_tool into do_after call. Do not override, do not call manually.
 /obj/item/proc/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,4 +1,4 @@
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, var/mono_adj = FALSE)	//WS Edit, Make tools and nearby airlocks use mono sound
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -37,14 +37,20 @@
 
 	for(var/P in listeners)
 		var/mob/M = P
+		var/ismono = FALSE
+		if(mono_adj)
+			ismono = get_dist(get_turf(P), turf_source) < 2	//If adjacent, play as mono
 		if(get_dist(M, turf_source) <= maxdistance)
-			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S)
+			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, ignore_direction = ismono)
 	for(var/P in SSmobs.dead_players_by_zlevel[source_z])
 		var/mob/M = P
+		var/ismono = FALSE
+		if(mono_adj)
+			ismono = get_dist(get_turf(P), turf_source) < 2
 		if(get_dist(M, turf_source) <= maxdistance)
-			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S)
+			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, ignore_direction = ismono)
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, distance_multiplier = 1, envwet = -10000, envdry = 0) //WS Edit Cit #7367 - Env Wet / Dry is Reverb
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, distance_multiplier = 1, envwet = -10000, envdry = 0, var/ignore_direction = FALSE) //WS Edit Cit #7367 - Env Wet / Dry is Reverb , Make items and nearby airlocks use mono sound
 	if(!client || !can_hear())
 		return
 
@@ -95,13 +101,13 @@
 
 		if(S.volume <= 0)
 			return //No sound
-
-		var/dx = turf_source.x - T.x // Hearing from the right/left
-		S.x = dx * distance_multiplier
-		var/dz = turf_source.y - T.y // Hearing from infront/behind
-		S.z = dz * distance_multiplier
-		var/dy = (turf_source.z - T.z) * 5 * distance_multiplier // Hearing from  above / below, multiplied by 5 because we assume height is further along coords.
-		S.y = dy
+		if(!ignore_direction)	//WS Edit, allow for disabling directionality.
+			var/dx = turf_source.x - T.x // Hearing from the right/left
+			S.x = dx * distance_multiplier
+			var/dz = turf_source.y - T.y // Hearing from infront/behind
+			S.z = dz * distance_multiplier
+			var/dy = (turf_source.z - T.z) * 5 * distance_multiplier // Hearing from  above / below, multiplied by 5 because we assume height is further along coords.
+			S.y = dy
 
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -108,7 +108,8 @@
 			S.z = dz * distance_multiplier
 			var/dy = (turf_source.z - T.z) * 5 * distance_multiplier // Hearing from  above / below, multiplied by 5 because we assume height is further along coords.
 			S.y = dy
-
+		else
+			S.y = 1	//To make sure the mono sound doesn't make you feel like you're dying.
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 
 	SEND_SOUND(src, S)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply adds in a nice var in the sounds system to play sounds in mono if the listener is right next to the source. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Opening doors to your left or right and using tools on them in deafening in a single ear and is overall unpleasant, this solves that issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Doors and tools now play in mono sound if you are right next to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
