### PR TITLE
[Port] Cleans up Cybernetic Lung code (#52143)

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -457,8 +457,7 @@
 	desc = "A basic cybernetic version of the lungs found in traditional humanoid entities."
 	icon_state = "lungs-c"
 	organ_flags = ORGAN_SYNTHETIC
-	safe_oxygen_min = 16
-	maxHealth = STANDARD_ORGAN_THRESHOLD*0.5
+	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
 
 	var/emp_vulnerability = 80	//Chance of permanent effects if emp-ed.
 
@@ -466,7 +465,6 @@
 	name = "cybernetic lungs"
 	desc = "A cybernetic version of the lungs found in traditional humanoid entities. Allows for greater intakes of oxygen than organic lungs, requiring slightly less pressure."
 	icon_state = "lungs-c-u"
-	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	safe_oxygen_min = 13
 	emp_vulnerability = 40
@@ -478,6 +476,7 @@
 	safe_toxins_max = 20
 	safe_co2_max = 20
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
+	safe_oxygen_min = 13
 	emp_vulnerability = 20
 
 	cold_level_1_threshold = 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I don't know how to do ports properly, so please tell me if I messed up.
Ports https://github.com/tgstation/tgstation/pull/52143 from tg, from 8 months ago.
Removes some redundant code from lungs.
Fixes T3 cybernetic lungs having a higher oxygen requirement than T2 lungs, which was presumably a coding mistake due to T3 not inheriting from T2.

## Why It's Good For The Game

Fixes a fairly minor bug, but a bug nonetheless.

## Changelog
:cl:
fix: Upgraded Cybernetic Lungs (Tier3) now have improved oxygen absorption, same as Cybernetic Lungs (Tier2)
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->