### PR TITLE
Fixes runtime in camp ruin spawning on whitesands

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -229,6 +229,24 @@
 
 	return null
 
+// Allows picks with non-integer weights and also 0
+// precision 1000 means it works up to 3 decimal points
+/proc/pickweight_float(list/L, precision=1000)
+	var/total = 0
+	var/item
+	for (item in L)
+		if (!L[item])
+			L[item] = 0
+		total += round(L[item]*precision)
+
+	total = rand(0, total)/precision
+	for (item in L)
+		total -=L [item]
+		if (total <= 0 && L[item])
+			return item
+
+	return null
+
 //Pick a random element from the list and remove it from the list.
 /proc/pick_n_take(list/L)
 	RETURN_TYPE(L[_].type)

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -102,7 +102,7 @@
 				forced = TRUE
 				break
 		else //Otherwise just pick random one
-			current_pick = pickweight(ruins_availible)
+			current_pick = pickweight_float(ruins_availible)
 
 		var/placement_tries = forced_turf ? 1 : PLACEMENT_TRIES //Only try once if we target specific turf
 		var/failed_to_place = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR fixes the startup runtime of ruin generation, as the ruins were using non-integer weights with the pickweight() function that only accepts integer weights
This means that `pickweight_float` has been added, which can handle non-integer weights up to a certain precision (by default, 3 decimal places, which is enough) and will no longer cause the proc to return null when it's not expected to.

## Why It's Good For The Game

Runtime errors bad
Fixes #817 

## Changelog
:cl: Urumasi
fix: Fixed whitesands ruin generation throwing a runtime error
/:cl:
