### PR TITLE
[Ready] Fixes various startup runtimes

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
@@ -350,7 +350,7 @@
 /turf/open/floor/plasteel/dark,
 /area/whitesands/surface/outdoors/unexplored)
 "jM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -1007,7 +1007,7 @@
 "CI" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/super,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
@@ -350,7 +350,7 @@
 /turf/open/floor/plasteel/dark,
 /area/whitesands/surface/outdoors/unexplored)
 "jM" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -1007,7 +1007,7 @@
 "CI" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/super,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -231,12 +231,12 @@
 
 // Allows picks with non-integer weights and also 0
 // precision 1000 means it works up to 3 decimal points
-/proc/pickweight_float(list/L, precision=1000)
+/proc/pickweight_float(list/L, default=1, precision=1000)
 	var/total = 0
 	var/item
 	for (item in L)
 		if (!L[item])
-			L[item] = 0
+			L[item] = default
 		total += round(L[item]*precision)
 
 	total = rand(0, total)/precision

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -69,6 +69,7 @@
 
 /area/ruin/unpowered/syndicate_lava_base/main
 	name = "Syndicate Lavaland Primary Hallway"
+	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA // WS edit - Fix various startup runtimes
 
 /area/ruin/unpowered/syndicate_lava_base/cargo
 	name = "Syndicate Lavaland Cargo Bay"

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -12,9 +12,9 @@
 	if(loot && loot.len)
 		var/loot_spawned = 0
 		while((lootcount-loot_spawned) && loot.len)
-			var/lootspawn = pickweight(loot)
+			var/lootspawn = pickweight_float(loot)
 			while(islist(lootspawn))
-				lootspawn = pickweight(lootspawn)
+				lootspawn = pickweight_float(lootspawn)
 			if(!lootdoubles)
 				loot.Remove(lootspawn)
 
@@ -481,7 +481,7 @@
 		stat_table[item] /= loot_count
 
 /obj/item/loot_table_maker/proc/pick_loot(lootpool) //selects path from loot table and returns it
-	var/lootspawn = pickweight(lootpool)
+	var/lootspawn = pickweight_float(lootpool)
 	while(islist(lootspawn))
-		lootspawn = pickweight(lootspawn)
+		lootspawn = pickweight_float(lootspawn)
 	return lootspawn

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -12,9 +12,9 @@
 	if(loot && loot.len)
 		var/loot_spawned = 0
 		while((lootcount-loot_spawned) && loot.len)
-			var/lootspawn = pickweight_float(loot)
+			var/lootspawn = pickweight_float(loot) // WS edit - Fix various startup runtimes
 			while(islist(lootspawn))
-				lootspawn = pickweight_float(lootspawn)
+				lootspawn = pickweight_float(lootspawn) // WS edit - Fix various startup runtimes
 			if(!lootdoubles)
 				loot.Remove(lootspawn)
 
@@ -481,7 +481,7 @@
 		stat_table[item] /= loot_count
 
 /obj/item/loot_table_maker/proc/pick_loot(lootpool) //selects path from loot table and returns it
-	var/lootspawn = pickweight_float(lootpool)
+	var/lootspawn = pickweight_float(lootpool) // WS edit - Fix various startup runtimes
 	while(islist(lootspawn))
-		lootspawn = pickweight_float(lootspawn)
+		lootspawn = pickweight_float(lootspawn) // WS edit - Fix various startup runtimes
 	return lootspawn

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -25,7 +25,7 @@
 /obj/item/gun/ballistic/automatic/toy/pistol
 	name = "foam force pistol"
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
-	icon_state = "pistol"
+	icon_state = "derringer" // WS edit - Fix various startup runtimes
 	bolt_type = BOLT_TYPE_LOCKING
 	w_class = WEIGHT_CLASS_SMALL
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -201,7 +201,8 @@
 			if(isalien(L))
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			var/obj/item/bodypart/B = L.get_bodypart(def_zone)
-			if(B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
+			// WS edit - Fix various startup runtimes
+			if(B?.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
 				do_sparks(2, FALSE, target.loc)
 				if(prob(25))
 					new /obj/effect/decal/cleanable/oil(target_loca)


### PR DESCRIPTION
## About The Pull Request

Map edit fixes this runtime which results in 3+ other runtimes:
*I have no idea why an injector next to a layer manifold throws a runtime and fails to connect to the pipe network*
```
runtime error: list index out of bounds
 - proc name: setPipenet (/obj/machinery/atmospherics/components/setPipenet)
 -   source file: components_base.dm,107
 -   usr: null
 -   src: the engine outlet injector (/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste)
 -   src.loc: the salted sand (169,80,5) (/turf/open/floor/plating/asteroid/whitesands)
 -   call stack:
 - the engine outlet injector (/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste): setPipenet(/datum/pipeline (/datum/pipeline), the layer adaptor (/obj/machinery/atmospherics/pipe/layer_manifold/visible))
 - /datum/pipeline (/datum/pipeline): build pipeline(the layer adaptor (/obj/machinery/atmospherics/pipe/layer_manifold/visible))
 - the layer adaptor (/obj/machinery/atmospherics/pipe/layer_manifold/visible): build network()
 - Atmospherics (/datum/controller/subsystem/air): setup pipenets()
 - Atmospherics (/datum/controller/subsystem/air): Initialize(734661)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
```
toy.dm#L28 fixes this runtime about a non-existing icon_state:
```
runtime error: /obj/item/gun/ballistic/automatic/toy/pistol/unrestricted does not have a valid icon state, icon=whitesands/icons/obj/guns/projectile.dmi, icon_state="pistol"([0x6001c7f]), icon_states=*snip*
 - proc name: stack trace (/datum/proc/stack_trace)
 -   source file: unsorted.dm,1120
 -   usr: null
 -   src: vending (/datum/asset/spritesheet/vending)
 -   call stack:
 - vending (/datum/asset/spritesheet/vending): stack trace("/obj/item/gun/ballistic/automa...")
 - vending (/datum/asset/spritesheet/vending): register()
 - vending (/datum/asset/spritesheet/vending): New()
 - get asset datum(/datum/asset/spritesheet/vendi... (/datum/asset/spritesheet/vending))
 - Assets (/datum/controller/subsystem/assets): Initialize(734707)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
```
lavaland.dm#L72 fixes this runtime when the turret controls can't find the base area in `GLOB.areas_by_type`:
```
runtime error: Bad control_area path for Base turret controls, Syndicate Lavaland Primary Hallway
 - proc name: stack trace (/datum/proc/stack_trace)
 -   source file: unsorted.dm,1120
 -   usr: null
 -   src: Base turret controls (/obj/machinery/turretid)
 -   src.loc: the floor (145,64,5) (/turf/open/floor/circuit/red)
 -   call stack:
 - Base turret controls (/obj/machinery/turretid): stack trace("Bad control_area path for Base...")
 - Base turret controls (/obj/machinery/turretid): Initialize(1)
 - Atoms (/datum/controller/subsystem/atoms): InitAtom(Base turret controls (/obj/machinery/turretid), /list (/list))
 - Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
 - Atoms (/datum/controller/subsystem/atoms): Initialize(794610)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
```

## Why It's Good For The Game

Getting runtimes is always bad, also this fixes your CI failing due to integration tests

## Changelog
:cl: Urumasi
fix: Fixed a few runtimes on startup
/:cl:
