### PR TITLE
Support spawn weights of 0 in loot tables and ruins

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -235,7 +235,7 @@
 	var/total = 0
 	var/item
 	for (item in L)
-		if (!L[item])
+		if (!isnum(L[item]))
 			L[item] = default
 		total += round(L[item]*precision)
 

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -28,6 +28,8 @@
 				else
 					if (loot_spawned)
 						spawned_loot.pixel_x = spawned_loot.pixel_y = ((!(loot_spawned%2)*loot_spawned/2)*-1)+((loot_spawned%2)*(loot_spawned+1)/2*1)
+			else
+				break // WS edit - Support spawn weights of 0 in loot tables and ruins
 			loot_spawned++
 	return INITIALIZE_HINT_QDEL
 
@@ -472,6 +474,8 @@
 	qdel(spawner_to_table)
 	for(var/i in 1 to loot_count)
 		var/loot_spawn = pick_loot(lootpool)
+		if(!loot_spawn) // WS edit - Support spawn weights of 0 in loot tables and ruins
+			continue
 		if(!(loot_spawn in spawned_table))
 			spawned_table[loot_spawn] = 1
 		else

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -103,6 +103,9 @@
 				break
 		else //Otherwise just pick random one
 			current_pick = pickweight_float(ruins_availible)
+			if(current_pick == null) // WS edit - Support spawn weights of 0 in loot tables and ruins
+				current_pick = list() // Couldn't pick a ruin from the list, which means they're all weight 0
+				continue
 
 		var/placement_tries = forced_turf ? 1 : PLACEMENT_TRIES //Only try once if we target specific turf
 		var/failed_to_place = TRUE


### PR DESCRIPTION
## About The Pull Request

This makes it possible to have a weight of 0 in loot spawners and ruins, and makes `pickweight_float` support 0 as advertised

## Why It's Good For The Game

I am a fool

## Changelog
:cl:
code: Loot and ruins can now have spawn weight of 0
/:cl:
