### PR TITLE
Fixed Custom-Material Table Sprites

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -240,8 +240,8 @@
 
 /obj/structure/table/greyscale
 	icon = 'icons/obj/smooth_structures/table_greyscale.dmi'
-	icon_state = "table_greyscale-0"
-	base_icon_state = "table_greyscale"
+	icon_state = "table-0"
+	base_icon_state = "table"
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstack = null //No buildstack, so generate from mat datums
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -240,8 +240,8 @@
 
 /obj/structure/table/greyscale
 	icon = 'icons/obj/smooth_structures/table_greyscale.dmi'
-	icon_state = "table-0"
-	base_icon_state = "table"
+	icon_state = "table-0"       // WS Edit - Custom Table Fix
+	base_icon_state = "table"    // WS Edit - Custom Table Fix
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstack = null //No buildstack, so generate from mat datums
 


### PR DESCRIPTION
## About The Pull Request

The sprites for custom tables appeared to be missing.  My original examples of this were titanium tables and sandstone tables being invisible.  This was caused by the icon_state's not matching what they were named in the dmi file.  The code was looking for table_greyscale-###, but in table_greyscale.dmi they were named table-###.  I changed the icon_state in the code, because it was a smaller change, and there is no name conflict within table_greyscale.dmi.

![image](https://user-images.githubusercontent.com/7697956/113496577-92a74700-94c0-11eb-99af-a63e33a019b4.png)

## Why It's Good For The Game

BugFix: Missing Table Sprites

## Changelog
:cl:
fix: You can once again construct tables out of meat, snow, bamboo, pizza, etc.
/:cl:
