### PR TITLE
Program Icon Fix for Bank Account Manager and Departmental Finances Manager

### DIFF
--- a/whitesands/code/modules/modular_computers/file_system/programs/account_management.dm
+++ b/whitesands/code/modules/modular_computers/file_system/programs/account_management.dm
@@ -2,7 +2,7 @@
 	filename = "acct_manage"
 	filedesc = "Bank Account Manager"
 	program_icon_state = "id"
-	program_icon = "bank"
+	program_icon = "university"
 	extended_desc = "This program allows the review and control of all the station's active bank accounts."
 	transfer_access = ACCESS_VAULT
 	required_access = ACCESS_VAULT

--- a/whitesands/code/modules/modular_computers/file_system/programs/department_management.dm
+++ b/whitesands/code/modules/modular_computers/file_system/programs/department_management.dm
@@ -2,7 +2,7 @@
 	filename = "dept_manage"
 	filedesc = "Departmental Finances Manager"
 	program_icon_state = "id"
-	program_icon = "money"
+	program_icon = "money-check-alt"
 	extended_desc = "This program allows management of a department's finances, such as changing paychecks."
 	transfer_access = ACCESS_HEADS
 	required_access = ACCESS_HEADS


### PR DESCRIPTION
## About The Pull Request

The program icons for Bank Account Manager and Departmental Finances Manager were missing.  This was because the icons were being referenced with the wrong names.  I looked up the correct names here: https://fontawesome.com/icons?d=gallery&p=2&m=free

![image](https://user-images.githubusercontent.com/7697956/114325526-24810680-9af6-11eb-9c56-805c66fe3745.png)


## Why It's Good For The Game

BugFix: Missing Financial Program Icons

## Changelog
:cl:
fix: Financial programs have icons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
