### PR TITLE
Fixes Clown Flower Superlube

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -237,9 +237,7 @@
 	desc = "A delightly devilish flower... you got a feeling where this is going."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "clownflower"
-	amount_per_transfer_from_this = 3
-	spray_range = 1
-	stream_range = 1
+	amount_per_transfer_from_this = 3  // WS edit - superlube fix
 	volume = 30
 	list_reagents = list(/datum/reagent/lube/superlube = 30)
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -237,6 +237,9 @@
 	desc = "A delightly devilish flower... you got a feeling where this is going."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "clownflower"
+	amount_per_transfer_from_this = 3
+	spray_range = 1
+	stream_range = 1
 	volume = 30
 	list_reagents = list(/datum/reagent/lube/superlube = 30)
 


### PR DESCRIPTION
## About The Pull Request

The clown flower is supposed to put super lube on the ground when sprayed.  However the clown flower wasn't transferring enough super lube to the ground to actually slip people.  amount_per_transfer_from_this was defaulting to 1 from /obj/item/reagent_containers/spray/waterflower.  Explicitly setting it to 3 in /obj/item/reagent_containers/spray/waterflower/superlube has resolved the issue.

## Why It's Good For The Game

BugFix: Clown Flower didn't slip people

## Changelog
:cl:
fix: Clown Flower sprays super lube onto tiles
/:cl:
