### PR TITLE
Allows augmentation surgery to be performed on yourself.

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -39,6 +39,7 @@
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 	requires_real_bodypart = TRUE
+	self_operable = TRUE //WS Edit - Re-enables self-augmentation. Other surgeries performed on organics still require autodoc or someone else to assist you.
 
 //SURGERY STEP SUCCESSES
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply allows the augmentation surgeries to be self-performed.

## Why It's Good For The Game

The autodoc can't replace your weak fleshy limbs with the strength and surety of metal. This was an easier solution to that debacle than fucking around with the innards of that flying spaghetti monster.

## Changelog
:cl:
tweak: Enables self-operation on Augmentation surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
