### PR TITLE
Allows Ethereals to Wear Underwear

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -14,7 +14,7 @@
 	brutemod = 1.25 //They're weak to punches
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
-	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR, FACEHAIR)    //WS Edit - Gave Ethereals Beards
+	species_traits = list(DYNCOLORS, AGENDER, HAIR, FACEHAIR)    //WS Edit - Gave Ethereals Beards & Underwear
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/ethereal
 	inherent_traits = list(TRAIT_NOHUNGER)


### PR DESCRIPTION
# About The Pull Request

Allows Ethereals to wear underwear.

Known Issue:

When a species is marked AGENDER (Ethereals), the gender of the character defaults to MALE.  This makes it so you can only wear the male set of underwear.  

Workaround:

1) Set species to one that allows gender to be set to "other," such as human
2) Set the character's gender to "other"
3) Change the character's species back to Ethereal
4) Now all underwear options are available

## Why It's Good For The Game

There was no mechanical reason for Ethereals to not be able to wear underwear, and more customization options is better.

Logging with Ethereal QoL issue #304 

## Changelog
:cl:
fix: Ethereals can wear underwear
/:cl:
