### PR TITLE
WS Ruins Fixes

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_envy.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_envy.dmm
@@ -1,14 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/open/floor/plating/asteroid/whitesands,
-/area/lavaland/surface/outdoors)
 "b" = (
-/turf/closed/mineral/random/whitesands,
-/area/lavaland/surface/outdoors)
-"d" = (
-/turf/closed/wall/rust,
-/area/ruin/unpowered)
-"e" = (
 /obj/structure/mirror{
 	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -19,18 +10,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"f" = (
-/obj/structure/mirror{
-	broken = 1;
-	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
-	icon_state = "mirror_broke";
-	pixel_x = 28
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+"d" = (
+/turf/closed/wall/rust,
 /area/ruin/unpowered)
-"g" = (
+"e" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/mirror{
 	broken = 1;
@@ -40,37 +23,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"h" = (
+"f" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"i" = (
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"j" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"k" = (
-/obj/structure/mirror{
-	broken = 1;
-	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
-	icon_state = "mirror_broke";
-	pixel_y = 28
-	},
-/obj/item/kitchen/knife/envy,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"l" = (
-/obj/structure/mirror{
-	broken = 1;
-	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
-	icon_state = "mirror_broke";
-	pixel_x = 28
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered)
-"m" = (
+"g" = (
 /obj/structure/mirror{
 	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -79,12 +36,15 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"n" = (
+"h" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
-"o" = (
+"i" = (
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"j" = (
 /obj/structure/mirror{
 	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -95,196 +55,164 @@
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
-"p" = (
+"k" = (
+/obj/structure/mirror{
+	broken = 1;
+	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
+	icon_state = "mirror_broke";
+	pixel_x = 28
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"l" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"m" = (
+/obj/structure/mirror{
+	broken = 1;
+	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
+	icon_state = "mirror_broke";
+	pixel_y = 28
+	},
+/obj/item/kitchen/knife/envy,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"p" = (
+/obj/structure/mirror{
+	broken = 1;
+	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
+	icon_state = "mirror_broke";
+	pixel_x = 28
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
 "A" = (
-/turf/open/floor/plating/asteroid/whitesands/dried,
-/area/lavaland/surface/outdoors)
+/turf/template_noop,
+/area/template_noop)
 "O" = (
-/turf/open/floor/plating/asteroid/whitesands/dried,
-/area/space)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+A
+A
+d
+d
+d
+d
+d
+d
+d
+d
+d
+d
+d
+d
+d
+d
+d
 "}
 (2,1,1) = {"
-a
-a
 A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-a
-"}
-(3,1,1) = {"
+d
+d
+d
 b
-A
-A
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-A
-a
-"}
-(4,1,1) = {"
-A
-A
-d
-d
-d
+e
+e
 e
 g
 g
 g
-m
-m
-m
-m
-m
-o
-m
+g
+g
 j
+g
+O
 d
-A
-a
+"}
+(3,1,1) = {"
+d
+d
+d
+d
+d
+f
+f
+i
+i
+i
+i
+i
+f
+i
+i
+i
+d
+"}
+(4,1,1) = {"
+d
+d
+d
+d
+d
+d
+m
+i
+i
+i
+i
+i
+i
+i
+i
+i
+l
 "}
 (5,1,1) = {"
-A
 d
 d
 d
 d
 d
-h
-h
 i
 i
 i
-i
+O
 i
 h
 i
 i
 i
+i
+i
 d
-A
-a
 "}
 (6,1,1) = {"
 A
 d
 d
 d
-d
-d
-d
 k
-i
-i
-i
-i
-i
-i
-i
-i
-i
+O
+p
+p
+p
+p
+p
+p
+p
+p
 p
 O
-a
+d
 "}
 (7,1,1) = {"
 A
-d
-d
-d
-d
-d
-i
-i
-i
-j
-i
-n
-i
-i
-i
-i
-i
-d
-A
-a
-"}
-(8,1,1) = {"
-A
-A
-d
-d
-d
-f
-j
-l
-l
-l
-l
-l
-l
-l
-l
-l
-j
-d
-A
-a
-"}
-(9,1,1) = {"
-b
-A
 A
 d
 d
@@ -301,28 +229,4 @@ d
 d
 d
 d
-A
-a
-"}
-(10,1,1) = {"
-b
-b
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-A
-a
 "}

--- a/_maps/RandomRuins/SandRuins/whitesands_surface_youreinsane.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_youreinsane.dmm
@@ -142,9 +142,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2";
 	initial_gas_mix = "ws_atmos"


### PR DESCRIPTION
## About The Pull Request

Removed extra pipe in WS SM ruin.

![image](https://user-images.githubusercontent.com/7697956/119234302-d139a500-baf2-11eb-90e7-004ac934a4c5.png)

After removing this, I stopped getting the runtime errors that have been causing the integration tests to fail when WS loads.

Removed unneeded empty turfs from around WS Envy ruin.  This also fixed a tile that was marked as being in space instead of on WS.

Before:
![image](https://user-images.githubusercontent.com/7697956/119234573-49549a80-baf4-11eb-8a8f-9a5b6e0d93d4.png)

After:
![image](https://user-images.githubusercontent.com/7697956/119234550-21fdcd80-baf4-11eb-90a2-b881a2b3186a.png)

## Why It's Good For The Game

BugFix: Tile outside WS envy without gravity
BugFix: Integration Tests (probably)

## Changelog
:cl:
fix: fixed area values on WS envy ruin
code: Integration tests should no longer sporadically fail
/:cl:
