### PR TITLE
Away Mission Gateway Fixes

### DIFF
--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -3110,8 +3110,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/academy/academyaft)
 "iW" = (
@@ -3538,9 +3540,6 @@
 /area/awaymission/academy/academygate)
 "kb" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
@@ -3556,10 +3555,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet,
-/area/awaymission/academy/academygate)
-"ke" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/awaymission/academy/academygate)
 "kf" = (
 /turf/open/floor/plating,
@@ -3581,12 +3576,6 @@
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plating,
 /area/awaymission/academy/academygate)
-"kj" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
 "kk" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -3599,36 +3588,6 @@
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
-"km" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
-"kn" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
-"ko" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
-"kp" = (
-/obj/machinery/gateway{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
 "kq" = (
 /mob/living/simple_animal/hostile/wizard,
 /obj/effect/turf_decal/tile/yellow{
@@ -3639,36 +3598,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/classrooms)
-"kr" = (
-/obj/machinery/gateway{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
-"ks" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
-"kt" = (
-/obj/machinery/gateway,
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
-"ku" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/awaymission/academy/academygate)
 "kv" = (
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
 "kw" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows"
 	},
 /area/awaymission/academy/headmaster)
 "kx" = (
@@ -3722,8 +3659,8 @@
 /area/awaymission/academy/academyaft)
 "kF" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows2"
 	},
 /area/awaymission/academy/headmaster)
 "kG" = (
@@ -3743,10 +3680,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
 "kI" = (
-/obj/structure/cable,
-/obj/machinery/gateway/centerstation{
-	calibrated = 1
-	},
+/obj/machinery/gateway/away,
 /turf/open/floor/plating,
 /area/awaymission/academy/academygate)
 "kJ" = (
@@ -4014,8 +3948,7 @@
 /area/awaymission/academy/academyengine)
 "lK" = (
 /obj/effect/immovablerod{
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -4328,8 +4261,8 @@
 /area/awaymission/academy/academycellar)
 "mW" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 4
+	dir = 4;
+	icon_state = "fakewindows"
 	},
 /area/awaymission/academy/headmaster)
 "mX" = (
@@ -4342,14 +4275,14 @@
 /area/space/nearstation)
 "mZ" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 1
+	dir = 1;
+	icon_state = "fakewindows"
 	},
 /area/awaymission/academy/headmaster)
 "na" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 1
+	dir = 1;
+	icon_state = "fakewindows2"
 	},
 /area/awaymission/academy/headmaster)
 "nb" = (
@@ -4368,38 +4301,38 @@
 /area/awaymission/academy/headmaster)
 "nd" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 1
+	dir = 1;
+	icon_state = "fakewindows"
 	},
 /area/awaymission/academy/academyengine)
 "ne" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 1
+	dir = 1;
+	icon_state = "fakewindows2"
 	},
 /area/awaymission/academy/academyengine)
 "nf" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 6
+	dir = 6;
+	icon_state = "fakewindows2"
 	},
 /area/awaymission/academy/headmaster)
 "ng" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows"
 	},
 /area/awaymission/academy/academyengine)
 "nh" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows2"
 	},
 /area/awaymission/academy/academyengine)
 "ni" = (
 /turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 4
+	dir = 4;
+	icon_state = "fakewindows"
 	},
 /area/awaymission/academy/academyengine)
 "nj" = (
@@ -13008,11 +12941,11 @@ jU
 jU
 jZ
 kb
-ke
-kj
-km
-kp
-ks
+kf
+kf
+kf
+kf
+kf
 kf
 kf
 ky
@@ -13140,9 +13073,9 @@ jY
 kc
 jW
 kf
-kn
+kf
 kI
-kt
+kf
 kf
 kf
 ky
@@ -13270,9 +13203,9 @@ jY
 kc
 jW
 kf
-ko
-kr
-ku
+kf
+kf
+kf
 kf
 kf
 ky

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -5333,7 +5333,6 @@
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "JN" = (
-/obj/effect/landmark/awaystart,
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = -32
 	},
@@ -5342,10 +5341,6 @@
 "LR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/awaymission/cabin)
-"Mk" = (
-/obj/effect/landmark/awaystart,
-/turf/open/floor/wood,
 /area/awaymission/cabin)
 "NN" = (
 /obj/structure/table,
@@ -5440,17 +5435,6 @@
 	},
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
-"WK" = (
-/obj/effect/landmark/awaystart,
-/turf/open/floor/carpet,
-/area/awaymission/cabin)
-"WT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
-	},
-/turf/open/floor/plating,
-/area/awaymission/cabin)
 "WB" = (
 /obj/structure/table/wood,
 /obj/machinery/plantgenes{
@@ -5459,6 +5443,13 @@
 	},
 /turf/open/floor/wood/cold,
 /area/awaymission/cabin/lumbermill)
+"WT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance"
+	},
+/turf/open/floor/plating,
+/area/awaymission/cabin)
 
 (1,1,1) = {"
 ab
@@ -35696,8 +35687,8 @@ aq
 aq
 aq
 aq
-Mk
-WK
+aq
+az
 ee
 an
 dB
@@ -35954,7 +35945,7 @@ cp
 aq
 aq
 aq
-WK
+az
 JN
 an
 dB
@@ -36210,8 +36201,8 @@ aq
 aq
 aq
 aq
-Mk
-WK
+aq
+az
 ee
 an
 dB

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -240,8 +240,8 @@
 "aX" = (
 /obj/machinery/porta_turret{
 	dir = 8;
-	set_obj_flags = "EMAGGED";
-	installation = /obj/item/gun/energy/lasercannon
+	installation = /obj/item/gun/energy/lasercannon;
+	set_obj_flags = "EMAGGED"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -382,8 +382,8 @@
 "bq" = (
 /obj/machinery/porta_turret{
 	dir = 8;
-	set_obj_flags = "EMAGGED";
-	installation = /obj/item/gun/energy/lasercannon
+	installation = /obj/item/gun/energy/lasercannon;
+	set_obj_flags = "EMAGGED"
 	},
 /turf/open/floor/plating,
 /area/awaymission/challenge/main)
@@ -901,150 +901,15 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/challenge/end)
-"cR" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"cS" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"cT" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"cV" = (
-/obj/machinery/gateway{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
 "cW" = (
-/obj/machinery/gateway/centerstation{
+/obj/machinery/gateway/away{
 	calibrated = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"cX" = (
-/obj/machinery/gateway{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"cY" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"cZ" = (
-/obj/machinery/gateway,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"da" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/challenge/end)
 "db" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit,
-/area/awaymission/challenge/end)
-"dc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
 /area/awaymission/challenge/end)
 "dd" = (
 /obj/structure/window/reinforced{
@@ -1110,20 +975,8 @@
 /turf/open/floor/plating,
 /area/awaymission/challenge/end)
 "dm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /mob/living/simple_animal/hostile/syndicate{
 	name = "Syndicate Technician"
-	},
-/turf/open/floor/plasteel/dark,
-/area/awaymission/challenge/end)
-"dn" = (
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/challenge/end)
@@ -1136,7 +989,6 @@
 /turf/open/floor/circuit,
 /area/awaymission/challenge/end)
 "dq" = (
-/obj/structure/cable,
 /obj/machinery/power/smes/magical,
 /turf/open/floor/circuit,
 /area/awaymission/challenge/end)
@@ -1144,7 +996,6 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/awaymission/challenge/end)
 "ds" = (
@@ -29071,9 +28922,9 @@ cd
 cn
 cH
 cN
-cR
-cV
-cY
+co
+co
+co
 db
 dg
 cd
@@ -29328,12 +29179,12 @@ cd
 cn
 cH
 cN
-cS
+co
 cW
-cZ
-dc
-dc
-dc
+co
+cd
+cd
+cd
 dm
 dq
 bP
@@ -29585,13 +29436,13 @@ cd
 cn
 cH
 cN
-cT
-cX
-da
+co
+co
+co
 db
 dh
 cd
-dn
+cd
 dr
 bP
 aa

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -962,20 +962,6 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/research)
-"cA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006;
-	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
-	temperature = 251
-	},
-/area/awaymission/moonoutpost19/syndicate)
 "cB" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -5948,15 +5934,6 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/research)
-"pb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/moonoutpost19/syndicate)
 "pB" = (
 /obj/machinery/computer/monitor/secret,
 /obj/effect/turf_decal/stripes/line{
@@ -5987,9 +5964,6 @@
 "qr" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006;
@@ -6159,9 +6133,6 @@
 /obj/machinery/gateway/away{
 	calibrated = 0
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plasteel/dark{
 	heat_capacity = 1e+006
 	},
@@ -6281,24 +6252,6 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/research)
-"zn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/moonoutpost19/syndicate)
 "zT" = (
 /obj/machinery/power/shieldwallgen{
 	locked = 0;
@@ -6570,9 +6523,6 @@
 	name = "Gateway";
 	req_access_txt = "150"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -6787,14 +6737,6 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/research)
-"Ua" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/moonoutpost19/syndicate)
 "Uc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6962,9 +6904,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -42036,13 +41975,13 @@ at
 aA
 aG
 tw
-zn
-Ua
+aG
+aA
 Yq
-pb
-pb
+bB
+bB
 Mr
-cA
+dm
 qr
 cK
 aU

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -689,10 +689,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
-"bR" = (
-/obj/effect/landmark/awaystart,
-/turf/open/floor/plasteel/dark,
-/area/awaymission/research/interior/gateway)
 "bS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -791,7 +787,6 @@
 /area/awaymission/research/interior/gateway)
 "cj" = (
 /obj/structure/window/reinforced,
-/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "cp" = (
@@ -3468,7 +3463,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/landmark/awaystart,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -4043,7 +4037,6 @@
 "jU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
-/obj/effect/landmark/awaystart,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "jV" = (
@@ -4864,7 +4857,6 @@
 "lT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/patriot,
-/obj/effect/landmark/awaystart,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lU" = (
@@ -5638,10 +5630,7 @@
 /area/awaymission/research/interior/maint)
 "vC" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
@@ -5698,12 +5687,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior)
 "wR" = (
-/obj/machinery/gateway/away{
-	calibrated = 0
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/machinery/gateway/away,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "xn" = (
@@ -5943,10 +5927,6 @@
 "EW" = (
 /obj/machinery/door/window/eastright{
 	dir = 2
-	},
-/obj/effect/landmark/awaystart,
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
@@ -6540,11 +6520,7 @@
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "Ya" = (
-/obj/effect/landmark/awaystart,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 
@@ -34670,8 +34646,8 @@ ad
 ad
 bl
 bz
-bR
-bR
+bz
+bz
 cj
 bz
 cD
@@ -35698,8 +35674,8 @@ ad
 ad
 bl
 bz
-bR
-bR
+bz
+bz
 cj
 Xs
 cF

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -3466,6 +3466,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/research/interior/bathroom)
 "iD" = (
@@ -5317,6 +5318,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/secure)
+"nM" = (
+/obj/structure/window/reinforced,
+/obj/effect/landmark/awaystart,
+/turf/open/floor/plasteel/dark,
+/area/awaymission/research/interior/gateway)
 "nY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance";
@@ -5632,6 +5638,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "vD" = (
@@ -5687,7 +5694,9 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior)
 "wR" = (
-/obj/machinery/gateway/away,
+/obj/machinery/gateway/away{
+	calibrated = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "xn" = (
@@ -5928,6 +5937,7 @@
 /obj/machinery/door/window/eastright{
 	dir = 2
 	},
+/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "Fb" = (
@@ -6014,6 +6024,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/secure)
+"JA" = (
+/obj/effect/landmark/awaystart,
+/turf/open/floor/plasteel/dark,
+/area/awaymission/research/interior/gateway)
 "JM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6301,6 +6315,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/security)
+"Sh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/awaystart,
+/turf/open/floor/plasteel/dark,
+/area/awaymission/research/interior/gateway)
 "Sq" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	auto_name = 1;
@@ -6416,6 +6437,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "VZ" = (
@@ -34905,9 +34927,9 @@ bl
 bA
 bS
 bY
-cj
-bz
-bz
+nM
+JA
+JA
 bl
 cp
 cp
@@ -35419,9 +35441,9 @@ bl
 bC
 bU
 ca
-cj
-Xs
-bz
+nM
+Sh
+JA
 bl
 cp
 cp

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -786,7 +786,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "cj" = (
-/obj/structure/window/reinforced,
+/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "cp" = (
@@ -4038,6 +4038,7 @@
 "jU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
+/obj/effect/landmark/awaystart,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "jV" = (
@@ -4858,6 +4859,7 @@
 "lT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/patriot,
+/obj/effect/landmark/awaystart,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lU" = (
@@ -5638,7 +5640,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "vD" = (
@@ -6024,10 +6025,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/secure)
-"JA" = (
-/obj/effect/landmark/awaystart,
-/turf/open/floor/plasteel/dark,
-/area/awaymission/research/interior/gateway)
 "JM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6315,13 +6312,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/security)
-"Sh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/awaystart,
-/turf/open/floor/plasteel/dark,
-/area/awaymission/research/interior/gateway)
 "Sq" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	auto_name = 1;
@@ -6437,7 +6427,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
 "VZ" = (
@@ -34667,10 +34656,10 @@ ad
 ad
 ad
 bl
-bz
-bz
-bz
 cj
+cj
+cj
+nM
 bz
 cD
 bl
@@ -34928,8 +34917,8 @@ bA
 bS
 bY
 nM
-JA
-JA
+bz
+bz
 bl
 cp
 cp
@@ -35442,8 +35431,8 @@ bC
 bU
 ca
 nM
-Sh
-JA
+Xs
+bz
 bl
 cp
 cp
@@ -35695,10 +35684,10 @@ ad
 ad
 ad
 bl
-bz
-bz
-bz
 cj
+cj
+cj
+nM
 Xs
 cF
 bl

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2512,27 +2512,6 @@
 "fF" = (
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
-"fG" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/awaymission/snowdin/post/gateway)
-"fH" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/awaymission/snowdin/post/gateway)
-"fI" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/awaymission/snowdin/post/gateway)
 "fJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -2893,29 +2872,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
-"gw" = (
-/obj/machinery/gateway{
-	dir = 8
-	},
+"gx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/awaymission/snowdin/post/gateway)
-"gx" = (
-/obj/machinery/gateway/centerstation{
+/obj/machinery/gateway/away{
 	calibrated = 0
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "gy" = (
-/obj/machinery/gateway{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
@@ -3261,30 +3226,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
-"hl" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/awaymission/snowdin/post/gateway)
 "hm" = (
-/obj/machinery/gateway,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "hn" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3530,15 +3477,10 @@
 /area/awaymission/snowdin/post/gateway)
 "hR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/landmark/awaystart,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "hS" = (
-/obj/effect/landmark/awaystart,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -3549,7 +3491,6 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/landmark/awaystart,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
@@ -3882,7 +3823,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "iB" = (
@@ -3895,10 +3835,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/landmark/awaystart,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -3910,7 +3846,6 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "iD" = (
@@ -4316,7 +4251,6 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "ju" = (
-/obj/effect/landmark/awaystart,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
@@ -4326,10 +4260,6 @@
 	piping_layer = 3;
 	pixel_x = 5;
 	pixel_y = 5
-	},
-/obj/effect/landmark/awaystart,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -4574,9 +4504,6 @@
 	piping_layer = 3;
 	pixel_x = 5;
 	pixel_y = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "snowdin_gate"
@@ -4905,9 +4832,6 @@
 	piping_layer = 3;
 	pixel_x = 5;
 	pixel_y = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5279,9 +5203,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post)
@@ -6736,9 +6657,9 @@
 "oo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4;
+	piping_layer = 3;
 	pixel_x = 5;
-	pixel_y = 5;
-	piping_layer = 3
+	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -6746,9 +6667,9 @@
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4;
+	piping_layer = 3;
 	pixel_x = 5;
-	pixel_y = 5;
-	piping_layer = 3
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
@@ -8164,9 +8085,9 @@
 "rI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	dir = 1;
+	piping_layer = 3;
 	pixel_x = 5;
-	pixel_y = 5;
-	piping_layer = 3
+	pixel_y = 5
 	},
 /obj/effect/light_emitter{
 	name = "cave light";
@@ -9748,10 +9669,10 @@
 /area/awaymission/snowdin/post/broken_shuttle)
 "wc" = (
 /obj/machinery/computer{
-	name = "Shuttle Transist Console";
 	desc = "A console meant for calling and sending a transit ferry. It seems iced-over and non-functional.";
 	dir = 1;
-	icon_screen = null
+	icon_screen = null;
+	name = "Shuttle Transist Console"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/snowdin/post/broken_shuttle)
@@ -9840,9 +9761,9 @@
 "wm" = (
 /obj/machinery/porta_turret/centcom_shuttle/weak{
 	desc = "A turret built with substandard parts and run down further with age.";
-	icon_state = "syndie_off";
 	dir = 9;
-	faction = list("pirate")
+	faction = list("pirate");
+	icon_state = "syndie_off"
 	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/cave)
@@ -9966,8 +9887,8 @@
 /area/awaymission/snowdin/outside)
 "wC" = (
 /obj/vehicle/ridden/atv{
-	icon_state = "atv";
-	dir = 4
+	dir = 4;
+	icon_state = "atv"
 	},
 /obj/effect/light_emitter{
 	name = "outdoor light";
@@ -10702,10 +10623,10 @@
 /area/awaymission/snowdin/cave)
 "yu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	name = "toxin out";
 	dir = 8;
+	frequency = 1442;
 	id_tag = "snowdin_toxins_mine_1";
-	frequency = 1442
+	name = "toxin out"
 	},
 /turf/open/floor/engine/vacuum,
 /area/awaymission/snowdin/cave)
@@ -11077,8 +10998,8 @@
 /area/awaymission/snowdin/post/minipost)
 "zq" = (
 /obj/vehicle/ridden/atv{
-	icon_state = "atv";
-	dir = 8
+	dir = 8;
+	icon_state = "atv"
 	},
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/minipost)
@@ -12330,8 +12251,8 @@
 /area/awaymission/snowdin/cave)
 "CP" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	icon_state = "heater"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -13303,8 +13224,8 @@
 /area/awaymission/snowdin/cave)
 "EN" = (
 /obj/machinery/sleeper/syndie{
-	icon_state = "sleeper_s";
-	dir = 1
+	dir = 1;
+	icon_state = "sleeper_s"
 	},
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
@@ -13316,8 +13237,8 @@
 "EP" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/sleeper/syndie{
-	icon_state = "sleeper_s";
-	dir = 1
+	dir = 1;
+	icon_state = "sleeper_s"
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/cave)
@@ -14593,8 +14514,8 @@
 /area/awaymission/snowdin/post/mining_main)
 "Ix" = (
 /obj/vehicle/ridden/atv{
-	icon_state = "atv";
-	dir = 1
+	dir = 1;
+	icon_state = "atv"
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -26658,9 +26579,9 @@ bE
 az
 en
 fh
-fG
-gw
-hl
+gy
+hm
+hm
 hR
 iA
 ju
@@ -26915,7 +26836,7 @@ bE
 dK
 eo
 fh
-fH
+gy
 gx
 hm
 hS
@@ -27172,7 +27093,7 @@ dk
 dK
 ep
 fh
-fI
+gy
 gy
 hn
 hT

--- a/_maps/RandomZLevels/speedway.dmm
+++ b/_maps/RandomZLevels/speedway.dmm
@@ -495,9 +495,7 @@
 	},
 /area/awaymission/speedway/lounge)
 "rE" = (
-/obj/machinery/gateway/away{
-	calibrated = 0
-	},
+/obj/machinery/gateway/away,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/speedway/lounge)
 "rT" = (
@@ -1143,7 +1141,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/speedway/track)
 "UF" = (
-/obj/effect/landmark/awaystart,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/speedway/lounge)
 "UP" = (

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -611,7 +611,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
+	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -636,7 +636,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
+	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -794,23 +794,23 @@
 /area/awaymission/undergroundoutpost45/central)
 "bV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
+	dir = 10
 	},
 /turf/closed/wall,
 /area/awaymission/undergroundoutpost45/central)
 "bW" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 351.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "bX" = (
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 351.9
 	},
@@ -1186,7 +1186,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "cM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
+	dir = 5
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -1270,7 +1270,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
+	dir = 10
 	},
 /turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/central)
@@ -1937,9 +1937,6 @@
 /area/awaymission/undergroundoutpost45/central)
 "ed" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/command{
 	name = "Gateway Chamber";
 	req_access_txt = "201"
@@ -2103,10 +2100,10 @@
 /area/awaymission/undergroundoutpost45/central)
 "eu" = (
 /turf/open/floor/plating{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
 	icon_plating = "asteroidplating";
 	icon_state = "asteroidplating";
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
@@ -2258,8 +2255,8 @@
 /area/awaymission/undergroundoutpost45/central)
 "eJ" = (
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -2636,8 +2633,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -2872,8 +2869,8 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -3028,13 +3025,13 @@
 /area/awaymission/undergroundoutpost45/central)
 "gc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
+	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/central)
 "gd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
+	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/central)
@@ -3051,8 +3048,8 @@
 "gf" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -3199,8 +3196,8 @@
 "gB" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -3330,60 +3327,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/awaymission/undergroundoutpost45/central)
-"gR" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
-"gS" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
-"gT" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
 "gU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
@@ -3471,8 +3414,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -3482,8 +3425,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -3514,8 +3457,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -3644,45 +3587,9 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
-"ht" = (
-/obj/machinery/gateway{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
 "hu" = (
-/obj/machinery/gateway/centerstation{
+/obj/machinery/gateway/away{
 	calibrated = 0
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
-"hv" = (
-/obj/machinery/gateway{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark{
 	heat_capacity = 1e+006
@@ -3929,7 +3836,7 @@
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -3941,7 +3848,7 @@
 "hV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -3966,47 +3873,7 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
-"hY" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
-"hZ" = (
-/obj/machinery/gateway,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
 "ia" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4190,9 +4057,6 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/window{
 	name = "Gateway Chamber";
 	req_access_txt = "201"
@@ -4500,7 +4364,7 @@
 /area/awaymission/undergroundoutpost45/gateway)
 "iX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
@@ -4628,17 +4492,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
-"ji" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -4910,8 +4763,8 @@
 "jL" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -4944,8 +4797,8 @@
 "jP" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -5865,18 +5718,7 @@
 	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/gateway)
-"lp" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/awaymission/undergroundoutpost45/gateway)
 "lq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -5885,9 +5727,6 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -6760,8 +6599,8 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -8525,8 +8364,8 @@
 	dir = 6
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -8536,8 +8375,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -8548,8 +8387,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -8642,8 +8481,8 @@
 	name = "air out"
 	},
 /turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
+	initial_gas_mix = "n2=10580;o2=2644";
+	name = "air floor"
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "pF" = (
@@ -8841,8 +8680,8 @@
 "qa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -8916,8 +8755,8 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500,TEMP=80"
+	initial_gas_mix = "n2=500,TEMP=80";
+	name = "Server Walkway"
 	},
 /area/awaymission/undergroundoutpost45/research)
 "qj" = (
@@ -9075,8 +8914,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -9086,8 +8925,8 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -9097,8 +8936,8 @@
 	dir = 9
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -9309,8 +9148,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500,TEMP=80"
+	initial_gas_mix = "n2=500,TEMP=80";
+	name = "Server Walkway"
 	},
 /area/awaymission/undergroundoutpost45/research)
 "qR" = (
@@ -9731,8 +9570,8 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500,TEMP=80"
+	initial_gas_mix = "n2=500,TEMP=80";
+	name = "Server Walkway"
 	},
 /area/awaymission/undergroundoutpost45/research)
 "rA" = (
@@ -9788,7 +9627,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -11098,7 +10937,7 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "tK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
+	dir = 5
 	},
 /turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/research)
@@ -11296,8 +11135,8 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -11764,7 +11603,7 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "uV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
+	dir = 5
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -11948,8 +11787,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -12174,8 +12013,8 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -12471,8 +12310,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13694,8 +13533,8 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13703,8 +13542,8 @@
 "yh" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13712,8 +13551,8 @@
 "yi" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13723,8 +13562,8 @@
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/human,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13733,8 +13572,8 @@
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13744,8 +13583,8 @@
 /obj/structure/glowshroom/single,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13754,8 +13593,8 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13763,8 +13602,8 @@
 "yn" = (
 /obj/structure/alien/weeds,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13773,8 +13612,8 @@
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13783,8 +13622,8 @@
 /obj/structure/alien/weeds,
 /obj/effect/mob_spawn/human,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13792,8 +13631,8 @@
 "yq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13801,8 +13640,8 @@
 "yr" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13811,8 +13650,8 @@
 /obj/structure/alien/weeds,
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13821,8 +13660,8 @@
 /obj/structure/alien/resin/wall,
 /obj/structure/alien/weeds,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13831,8 +13670,8 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13840,8 +13679,8 @@
 "yz" = (
 /obj/structure/alien/resin/membrane,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13850,8 +13689,8 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13859,8 +13698,8 @@
 "yB" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13869,8 +13708,8 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/human,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13880,8 +13719,8 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/human,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -13891,8 +13730,8 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/mob_spawn/human,
 /turf/open/floor/plating/asteroid{
-	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
@@ -33300,9 +33139,9 @@ ad
 ad
 gv
 gJ
-gR
-ht
-hY
+ia
+ia
+ia
 it
 iO
 jh
@@ -33557,16 +33396,16 @@ ad
 ad
 gv
 gJ
-gS
+ia
 hu
-hZ
+ia
 iu
-iP
-ji
-iP
+mb
+jj
+mb
 ed
-iP
-lp
+mb
+mb
 jI
 mC
 gL
@@ -33814,8 +33653,8 @@ ad
 ad
 gw
 gJ
-gT
-hv
+ia
+ia
 ia
 iv
 iQ

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7551,8 +7551,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aEQ" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/gateway,
+/obj/machinery/computer/gateway_control,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aER" = (
@@ -7566,6 +7565,7 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/paper/pamphlet/gateway,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aES" = (
@@ -28230,9 +28230,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "dus" = (
@@ -30619,13 +30616,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fdS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "feg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garden Maintenance";
@@ -43435,9 +43425,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "nBN" = (
@@ -46979,9 +46966,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "pRl" = (
@@ -47231,9 +47215,6 @@
 /area/science/mixing)
 "qaX" = (
 /obj/machinery/gateway/centerstation,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "qbn" = (
@@ -47971,24 +47952,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"qzq" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "qzI" = (
 /obj/item/stack/sheet/cardboard,
 /obj/structure/closet,
@@ -48591,9 +48554,6 @@
 	req_access_txt = "62"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -48905,9 +48865,6 @@
 	pixel_x = -1;
 	pixel_y = -24;
 	req_access_txt = "31"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -54777,9 +54734,6 @@
 /area/maintenance/starboard/fore)
 "vbQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "vcm" = (
@@ -57352,12 +57306,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wIr" = (
@@ -57700,9 +57648,6 @@
 /area/crew_quarters/heads/hor)
 "wTj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "wTH" = (
@@ -83141,10 +83086,10 @@ drZ
 ayG
 kEy
 qaX
-qzq
+kEy
 nBp
-fdS
-fdS
+vbQ
+vbQ
 dur
 vbQ
 gDN

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -41164,6 +41164,10 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/bot,
+/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway,
+/obj/item/clipboard,
 /turf/open/floor/plasteel,
 /area/gateway)
 "cyH" = (
@@ -79122,13 +79126,11 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
 "gXc" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/paper/pamphlet/gateway,
-/obj/item/paper/pamphlet/gateway,
-/obj/item/paper/pamphlet/gateway,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/gateway_control{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "gXn" = (

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -7274,7 +7274,7 @@
 /turf/open/transparent/openspace,
 /area/maintenance/central)
 "rk" = (
-/obj/machinery/gateway,
+/obj/machinery/gateway/centerstation,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "rl" = (
@@ -16096,6 +16096,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/solar/port/fore)
+"QK" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/computer/gateway_control,
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "QM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56248,7 +56262,7 @@ nQ
 oC
 oC
 pS
-qG
+QK
 Xl
 rU
 Cn

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -632,7 +632,6 @@
 	},
 /area/space/nearstation)
 "aeH" = (
-/obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
@@ -640,6 +639,9 @@
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
+	},
+/obj/machinery/computer/gateway_control{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21587,10 +21587,11 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "bLB" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/gateway,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/machinery/computer/gateway_control{
+	dir = 8
 	},
 /turf/open/floor/plasteel{
 	dir = 1
@@ -82792,6 +82793,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/item/paper/pamphlet/gateway,
 /turf/open/floor/plasteel{
 	dir = 1
 	},

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -4534,6 +4534,8 @@
 "axg" = (
 /obj/structure/table,
 /obj/machinery/recharger,
+/obj/item/storage/firstaid/regular,
+/obj/item/paper/pamphlet/gateway,
 /turf/open/floor/plasteel,
 /area/gateway)
 "axk" = (
@@ -12960,9 +12962,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dCl" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
+/obj/machinery/computer/gateway_control{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "dCL" = (

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -2721,12 +2721,10 @@
 	c_tag = "Gateway";
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/paper/pamphlet/gateway,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/computer/gateway_control,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "auC" = (
@@ -4412,6 +4410,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/paper/pamphlet/gateway,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aHy" = (
@@ -21299,9 +21299,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/box,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "mmv" = (
@@ -31550,9 +31547,6 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -32010,9 +32004,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "uIE" = (
@@ -32071,9 +32062,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "uKy" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4299,6 +4299,7 @@
 	pixel_x = 32
 	},
 /obj/item/radio/off,
+/obj/item/paper/pamphlet,
 /turf/open/floor/plasteel,
 /area/gateway)
 "ash" = (
@@ -5581,15 +5582,14 @@
 	c_tag = "Gateway";
 	dir = 4
 	},
-/obj/structure/table,
 /obj/structure/sign/warning/biohazard{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/paper/pamphlet,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/gateway_control,
 /turf/open/floor/plasteel,
 /area/gateway)
 "awI" = (

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -259,8 +259,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 		if(!GLOB.the_gateway)
 			to_chat(user,"<span class='warning'>Home gateway is not responding!</span>")
 		if(GLOB.the_gateway.target)
-			to_chat(user,"<span class='warning'>Home gateway already in use!</span>")
-			return
+			GLOB.the_gateway.deactivate()          // WS Edit - Force Home Portal to Connect
 		activate(GLOB.the_gateway.destination)
 	else
 		deactivate()


### PR DESCRIPTION
## About The Pull Request

We've had multiple issues with away missions and the gateways.  This PR seeks to resolve them.

Important: I only fixed the gateway connections.  I did not modernize the away missions to play nicely with Monstermos or other modern features.

Issue 1 - Only an admin can start the gateway

An admin would have to teleport to the away mission and activate the gateway from that side.  This meant an admin was required to play on them.

This is solved by adding the gateway control console to each station.  It allows players to control gateway connections from a console.

To make room for the console, I moved the med kit and gateway pamphlet onto the same table.

![image](https://user-images.githubusercontent.com/7697956/120123107-9ed31c00-c172-11eb-9751-0b0bb206f7e0.png)

Issue 2 - Incorrect gateway type

Gateways on a station must be of type /obj/machinery/gateway/centerstation, and gateways on an away mission must be of type /obj/machinery/gateway/away.

This also includes the weird situation where there were 9 gateways on an away mission, all of the wrong type.

I corrected this on Galaxy Station, The Academy, Challenge, and Snowdin.

Issue 3 - Incorrect gateway connection mode

Station and away mission gateways will typically connect in one of two ways:
1) The away gateway is calibrated, so you can travel in both directions
2) The away gateway is not calibrated, meaning you cannot travel from the station gateway to the away gateway.  This is almost always paired with the landmark obj/effect/landmark/awaystart.  When this landmark exists on an away mission, the station gateway will allow a one-way connection to a random awaystart landmark.  The away gateway can then be activated from the away side to return to the station.

The awaystart landmark mode has a wait period of 30 minutes (set in game_option.txt) before it can be used.  Switching to a calibrated gateway allows content-expansion type maps to be accessed immediately.  I applied this change to the Speedway.

Issue 4 - Station gateways connected to awaystart landmarks could not connect to the away gateway

When you connect the station gateway to awaystart landmarks, the station gateway will refuse connections from an away gateway.  This would strand players in the away mission, unless another player turned the gateway off from station side.

The solution to this was to force the station gateway to disconnect from the awaystart landmark whenever an away gateway attempts to connect.

This is the only code change in this PR.

Issue 5 - Unneeded cable connected to away gateways

Gateways receive power from the area they are in (APC or auto-powered area).  When the APC is off, gateways do not receive power from powered cable lines under them.  However several away missions run these cable lines anyway.  This is misleading to mappers who try to use existing away missions as examples.  So I removed these unneeded cable lines.

Notes:

Away missions are selected from awaymissions.txt.  Uncomment the line of the away mission you want available in the round.  I highly recommend only uncommenting one at a time.  I saw notes in the code about random selection if multiple are uncommented.

Away missions are loaded by either using the verb load-away-mission or by uncommenting ROUNDSTART_AWAY in game_options.txt.

## Why It's Good For The Game

You can travel to the away missions again, and more content is better.

## Changelog
:cl:
add: Added gateway control console to each station
fix: Away missions and gateways work again
/:cl:
