### PR TITLE
Put Sandbox Panel Verb Back in Sandbox Tab

### DIFF
--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -9,6 +9,7 @@ GLOBAL_VAR_INIT(hsboxspawn, TRUE)
 
 /mob/proc/sandbox_panel()
 	set name = "Sandbox Panel"
+	set category = "Sandbox"    // WS edit - makes verb visible
 	if(sandbox)
 		sandbox.update()
 


### PR DESCRIPTION
## About The Pull Request

This makes the Sandbox Panel verb visible again assuming it's sandbox mode and the player was present at round start.

This does not fix any of the other issues with sandbox mode that were mentioned in #844 

## Why It's Good For The Game

BugFix: The easy part of issue #844

## Changelog
:cl:
fix: Sandbox panel verb is visible in sandbox mode
/:cl: