### PR TITLE
Allows admins to pick icemoon

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -3,7 +3,7 @@
 //defaults to box
 //  -Cyberboss
 
-GLOBAL_LIST_INIT(mining_maps, list("lavaland" = 1, "whitesands" = 1, "random" = 0))
+GLOBAL_LIST_INIT(mining_maps, list("lavaland" = 1, "whitesands" = 1, "icemoon" = 0, "random" = 0))
 GLOBAL_VAR_INIT(current_mining_map, "random")
 GLOBAL_VAR_INIT(next_mining_map, "random")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Allows admins to pick icemoon as the next mining map, but does not allow it to be picked randomly.

## Why It's Good For The Game

Gives admins more choice of mining maps

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Icemoon can now be selected by admins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
